### PR TITLE
Feat: Add tests for read-only and public functions

### DIFF
--- a/src/citycoin-client.ts
+++ b/src/citycoin-client.ts
@@ -13,7 +13,7 @@ export enum ErrCode {
   ERR_IMMATURE_TOKEN_REWARD,
   ERR_UNAUTHORIZED,
   ERR_ALREADY_CLAIMED,
-  ERR_STACKING_NOT_AVALIABLE,
+  ERR_STACKING_NOT_AVAILABLE,
   ERR_CANNOT_STACK,
   ERR_INSUFFICIENT_BALANCE,
   ERR_ALREADY_MINED,
@@ -260,7 +260,7 @@ export class CityCoinClient {
     );
   }
 
-  claimStackingRewad(targetRewardCycle: number, sender: Account): Tx {
+  claimStackingReward(targetRewardCycle: number, sender: Account): Tx {
     return Tx.contractCall(
       this.contractName,
       "claim-stacking-reward",

--- a/src/citycoin-client.ts
+++ b/src/citycoin-client.ts
@@ -45,6 +45,9 @@ export class CityCoinClient {
     return result;
   }
 
+  public getContractAddress(): string {
+    return `${this.deployer.address}.${this.contractName}`;
+  }
   /**
    * Mints token to make testing easier.
    * 

--- a/tests/citycoin_test.ts
+++ b/tests/citycoin_test.ts
@@ -161,7 +161,7 @@ describe('[CityCoin]', () => {
     });
 
     describe("getBlockWinner()", () => {
-      it("should select correct winer", () => {
+      it("should select correct winner", () => {
         const miners = new MinersList();
         miners.push(
           { miner: wallet_1, amountUstx: 1 },
@@ -289,7 +289,7 @@ describe('[CityCoin]', () => {
       it("throws ERR_STACKING_NOT_AVAILABLE error", () => {
         const result = client.canMineTokens(wallet_3, 0, 10, minersRec).result;
 
-        result.expectErr().expectUint(ErrCode.ERR_STACKING_NOT_AVALIABLE);
+        result.expectErr().expectUint(ErrCode.ERR_STACKING_NOT_AVAILABLE);
       });
 
       it("throws ERR_ROUND_FULL error", () => {
@@ -341,7 +341,7 @@ describe('[CityCoin]', () => {
         })
       });
 
-      it("throws ERR_CANNOT_STACK error if amoutToken = 0", () => {
+      it("throws ERR_CANNOT_STACK error if amountToken = 0", () => {
         const nowStacksHeight = 502;
         const startStacksHeight = 510;
         const amountToken = 0;
@@ -375,7 +375,7 @@ describe('[CityCoin]', () => {
         result.expectUint(0);
       });
 
-      it("returns 1000 if miners commited only 1000ustx and there is only one stacker", () => {
+      it("returns 1000 if miners committed only 1000ustx and there is only one stacker", () => {
         const stacker = wallet_1;
         const miner = wallet_2;
         const minerCommitment = 1000;
@@ -387,15 +387,15 @@ describe('[CityCoin]', () => {
           client.stackTokens(5000, 5, targetRewardCycle, stacker),
         ]);
 
-        // move chain forward to jump into 1st staking cycle
+        // move chain forward to jump into 1st stacking cycle
         chain.mineEmptyBlock(500);
 
-        // mine some tokes
+        // mine some tokens
         chain.mineBlock([
           client.mineTokens(minerCommitment, miner)
         ]);
 
-        // move chain forward to jump into 2nd staking cycle
+        // move chain forward to jump into 2nd stacking cycle
         const block = chain.mineEmptyBlock(500);
 
         const result = client.getEntitledStackingReward(stacker, targetRewardCycle, block.block_height).result;
@@ -450,7 +450,7 @@ describe('[CityCoin]', () => {
           client.stackTokens(100, 0, 1, wallet_1)
         ]);
 
-        block.receipts[0].result.expectErr().expectUint(ErrCode.ERR_STACKING_NOT_AVALIABLE);
+        block.receipts[0].result.expectErr().expectUint(ErrCode.ERR_STACKING_NOT_AVAILABLE);
         assertEquals(block.receipts[0].events.length, 0);
       });
 
@@ -463,7 +463,7 @@ describe('[CityCoin]', () => {
         assertEquals(block.receipts[0].events.length, 0);
       });
 
-      it("succeedes and causes one ft_transfer_event", () => {
+      it("succeeds and causes one ft_transfer_event", () => {
         const block = chain.mineBlock([
           client.ftMint(100, wallet_1),
           client.stackTokens(100, 5, 1, wallet_1)
@@ -475,7 +475,7 @@ describe('[CityCoin]', () => {
         // check number of events 
         assertEquals(block.receipts[0].events.length, 1);
 
-        // checke events
+        // check events
         block.receipts[1].events.expectFungibleTokenTransferEvent(
           100,
           wallet_1.address,
@@ -486,7 +486,7 @@ describe('[CityCoin]', () => {
       });
     });
 
-    describe("mine-tokesn()", () => {
+    describe("mine-tokens()", () => {
       beforeEach(() => {
         setupCleanEnv();
       });
@@ -503,7 +503,7 @@ describe('[CityCoin]', () => {
         assertEquals(receipt.events.length, 0)
       });
 
-      it("throws ERR_INSUFFICIENT_BALANCE error when mier wants to commit more than he have", () => {
+      it("throws ERR_INSUFFICIENT_BALANCE error when miner wants to commit more than they have", () => {
         const block = chain.mineBlock([
           client.mineTokens(wallet_1.balance + 1, wallet_1)
         ]);
@@ -515,7 +515,7 @@ describe('[CityCoin]', () => {
         assertEquals(receipt.events.length, 0)
       })
 
-      it("throws ERR_ALREADY_MINED error when minner wants mine twice at the same block", () => {
+      it("throws ERR_ALREADY_MINED error when miner wants mine twice at the same block", () => {
         const block = chain.mineBlock([
           client.mineTokens(10, wallet_1),
           client.mineTokens(10, wallet_1),
@@ -527,7 +527,7 @@ describe('[CityCoin]', () => {
         assertEquals(receipt_err.events.length, 0)
       })
 
-      it("succeedes and causes one stx_transfer_event", () => {
+      it("succeeds and causes one stx_transfer_event", () => {
         const amount = 20000;
         const block = chain.mineBlock([
           client.mineTokens(amount, wallet_1),
@@ -539,7 +539,7 @@ describe('[CityCoin]', () => {
         // check number of events
         assertEquals(block.receipts[0].events.length, 1)
 
-        // checke event details
+        // check event details
         block.receipts[0].events.expectSTXTransferEvent(
           amount,
           wallet_1.address,
@@ -553,9 +553,9 @@ describe('[CityCoin]', () => {
         setupCleanEnv();
       });
 
-      it("throws ERR_NOTHIG_TO_REDEEM error when stacker didn't stack at all", () => {
+      it("throws ERR_NOTHING_TO_REDEEM error when stacker didn't stack at all", () => {
         const block = chain.mineBlock([
-          client.claimStackingRewad(0, wallet_1)
+          client.claimStackingReward(0, wallet_1)
         ]);
 
         const receipt = block.receipts[0];
@@ -574,25 +574,25 @@ describe('[CityCoin]', () => {
           client.stackTokens(5000, 5, 1, stacker),
         ]);
 
-        // advance chain forward to jump into 1st staking cycle
+        // advance chain forward to jump into 1st stacking cycle
         chain.mineEmptyBlock(500);
 
-        // mine some tokes
+        // mine some tokens
         chain.mineBlock([
           client.mineTokens(50000, miner),
         ]);
 
-        // advance chain forward to jump into 2nd staking cycle
+        // advance chain forward to jump into 2nd stacking cycle
         chain.mineEmptyBlock(500);
 
         // claim first time
         chain.mineBlock([
-          client.claimStackingRewad(1, stacker),
+          client.claimStackingReward(1, stacker),
         ]);
 
         // try to claim second time
         const block = chain.mineBlock([
-          client.claimStackingRewad(1, stacker),
+          client.claimStackingReward(1, stacker),
         ]);
 
         const receipt = block.receipts[0];
@@ -602,7 +602,7 @@ describe('[CityCoin]', () => {
       });
 
 
-      it("suceeds and causes one stx_transfer_event event", () => {
+      it("succeeds and causes one stx_transfer_event event", () => {
         const miner_1 = wallet_1;
         const miner_2 = wallet_2
         const stacker = wallet_3;
@@ -614,31 +614,31 @@ describe('[CityCoin]', () => {
           client.stackTokens(5000, 5, 1, stacker),
         ]);
 
-        // advance chain forward to jump into 1st staking cycle
+        // advance chain forward to jump into 1st stacking cycle
         chain.mineEmptyBlock(500);
 
-        // mine some tokes
+        // mine some tokens
         chain.mineBlock([
           client.mineTokens(minerCommitment, miner_1),
           client.mineTokens(minerCommitment, miner_2)
         ]);
 
-        // advance chain forward to jump into 2nd staking cycle
+        // advance chain forward to jump into 2nd stacking cycle
         chain.mineEmptyBlock(500);
 
         const block = chain.mineBlock([
-          client.claimStackingRewad(1, stacker)
+          client.claimStackingReward(1, stacker)
         ]);
 
         const receipt = block.receipts[0];
 
-        // check return valu
+        // check return value
         receipt.result.expectOk().expectBool(true);
 
-        // check evens count
+        // check events count
         assertEquals(receipt.events.length, 1);
 
-        // checke event details
+        // check event details
         receipt.events.expectSTXTransferEvent(
           minerCommitment * 2,
           client.getContractAddress(),

--- a/tests/citycoin_test.ts
+++ b/tests/citycoin_test.ts
@@ -1,5 +1,5 @@
 import { Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.6.0/index.ts';
-import { assertEquals } from "https://deno.land/std@0.93.0/testing/asserts.ts";
+import { assertEquals, assert } from "https://deno.land/std@0.93.0/testing/asserts.ts";
 
 import {
   afterEach,
@@ -9,7 +9,14 @@ import {
   it,
 } from "https://deno.land/x/test_suite@v0.7.0/mod.ts";
 
-import { CityCoinClient } from "../src/citycoin-client.ts"
+import {
+  CityCoinClient,
+  MinersList,
+  MinersRec,
+  ErrCode,
+  FIRST_STACKING_BLOCK,
+  REWARD_CYCLE_LENGTH
+} from "../src/citycoin-client.ts"
 
 describe('[CityCoin]', () => {
   let chain: Chain;
@@ -18,6 +25,7 @@ describe('[CityCoin]', () => {
   let deployer: Account;
   let wallet_1: Account;
   let wallet_2: Account;
+  let wallet_3: Account;
 
   function setupCleanEnv() {
     (Deno as any).core.ops();
@@ -36,6 +44,7 @@ describe('[CityCoin]', () => {
     deployer = accounts.get('deployer')!;
     wallet_1 = accounts.get('wallet_1')!;
     wallet_2 = accounts.get('wallet_2')!;
+    wallet_3 = accounts.get('wallet_3')!;
 
     client = new CityCoinClient(chain, deployer);
   }
@@ -122,6 +131,310 @@ describe('[CityCoin]', () => {
         const result = client.getTokenUri().result;
 
         result.expectOk().expectNone();
+      });
+    });
+  });
+
+  describe("Read only functions:", () => {
+    setupCleanEnv();
+
+    describe("get-block-commit-total()", () => {
+      it("should return 0 when miners list is empty", () => {
+        const miners = new MinersList();
+
+        const result = client.getBlockCommitTotal(miners).result;
+
+        result.expectUint(0);
+      })
+
+      it("should return 100", () => {
+        const miners = new MinersList();
+        miners.push(
+          { miner: wallet_1, amountUstx: 30 },
+          { miner: wallet_2, amountUstx: 70 },
+        )
+
+        const result = client.getBlockCommitTotal(miners).result;
+
+        result.expectUint(100);
+      });
+    });
+
+    describe("getBlockWinner()", () => {
+      it("should select correct winer", () => {
+        const miners = new MinersList();
+        miners.push(
+          { miner: wallet_1, amountUstx: 1 },
+          { miner: wallet_2, amountUstx: 2 },
+          { miner: wallet_3, amountUstx: 3 },
+        );
+
+        const known_rnd_winners = [0, 1, 1, 2, 2, 2, 0, 1, 1, 2, 2, 2, 0]
+
+        known_rnd_winners.forEach((e, i) => {
+          let result = client.getBlockWinner(i, miners).result;
+          let winner = result.expectSome().expectTuple();
+          let expectedWinner = miners.getFormatted(e)
+
+          assertEquals(winner, expectedWinner);
+        });
+      });
+
+      it("should return no winner if there are no miners", () => {
+        const result = client.getBlockWinner(0, new MinersList()).result;
+
+        result.expectNone();
+      });
+    });
+
+    describe("has-mined-in-list()", () => {
+      const miners = new MinersList();
+      miners.push(
+        { miner: wallet_1, amountUstx: 1 },
+        { miner: wallet_2, amountUstx: 2 },
+      );
+
+      it("returns true if miner is in a list", () => {
+        const result = client.hasMinedInList(wallet_2, miners).result;
+
+        result.expectBool(true);
+      })
+
+      it("returns false if miner is not in a list", () => {
+        const result = client.hasMinedInList(wallet_3, miners).result;
+
+        result.expectBool(false);
+      });
+    });
+
+    describe("can-claim-tokens()", () => {
+      const miners = new MinersList();
+      miners.push(
+        { miner: wallet_1, amountUstx: 1 },
+        { miner: wallet_2, amountUstx: 2 },
+        { miner: wallet_3, amountUstx: 3 },
+      );
+
+      const claimedRec = new MinersRec(miners, true);
+      const unclaimedRec = new MinersRec(miners, false);
+      const tokenRewardMaturity = 100;
+
+
+      it("returns true", () => {
+        const currentStacksBlock = tokenRewardMaturity + 1;
+        const results = [
+          client.canClaimTokens(wallet_1, 0, 0, unclaimedRec, currentStacksBlock).result,
+          client.canClaimTokens(wallet_2, 0, 1, unclaimedRec, currentStacksBlock).result,
+          client.canClaimTokens(wallet_2, 0, 2, unclaimedRec, currentStacksBlock).result,
+          client.canClaimTokens(wallet_3, 0, 3, unclaimedRec, currentStacksBlock).result,
+          client.canClaimTokens(wallet_3, 0, 4, unclaimedRec, currentStacksBlock).result,
+          client.canClaimTokens(wallet_3, 0, 5, unclaimedRec, currentStacksBlock).result,
+          client.canClaimTokens(wallet_1, 0, 6, unclaimedRec, currentStacksBlock).result,
+        ];
+
+        results.forEach((result) => {
+          result.expectOk().expectBool(true);
+        });
+      });
+
+      it("throws ERR_UNAUTHORIZED error", () => {
+        const currentStacksBlock = tokenRewardMaturity + 1;
+
+        const results = [
+          client.canClaimTokens(wallet_2, 0, 0, unclaimedRec, currentStacksBlock).result,
+          client.canClaimTokens(wallet_1, 0, 1, unclaimedRec, currentStacksBlock).result,
+          client.canClaimTokens(wallet_3, 0, 2, unclaimedRec, currentStacksBlock).result,
+        ]
+
+        results.forEach((result) => {
+          result.expectErr().expectUint(ErrCode.ERR_UNAUTHORIZED);
+        });
+      });
+
+      it("throws ERR_IMMATURE_TOKEN_REWARD", () => {
+        const result = client.canClaimTokens(wallet_1, 0, 0, unclaimedRec, tokenRewardMaturity).result;
+
+        result.expectErr().expectUint(ErrCode.ERR_IMMATURE_TOKEN_REWARD);
+      });
+
+      it("throws ERR_ALREADY_CLAIMED error", () => {
+        const currentStacksBlock = tokenRewardMaturity + 1;
+        const result = client.canClaimTokens(wallet_1, 0, 0, claimedRec, currentStacksBlock).result;
+
+        result.expectErr().expectUint(ErrCode.ERR_ALREADY_CLAIMED);
+      });
+    });
+
+    describe("can-mine-tokens()", () => {
+      const miners = new MinersList();
+      miners.push(
+        { miner: wallet_1, amountUstx: 1 },
+        { miner: wallet_2, amountUstx: 2 },
+      );
+
+      const minersFull = new MinersList();
+      for (let i = 1; i <= 32; i++) {
+        minersFull.push({ miner: wallet_1, amountUstx: 10 })
+      }
+
+      const minersRec = new MinersRec(miners, false);
+      const minersRecFull = new MinersRec(minersFull, false);
+
+      it("returns true", () => {
+        const result = client.canMineTokens(wallet_3, 1, 10, minersRec).result;
+
+        result.expectOk().expectBool(true);
+      });
+
+      it("throws ERR_STACKING_NOT_AVAILABLE error", () => {
+        const result = client.canMineTokens(wallet_3, 0, 10, minersRec).result;
+
+        result.expectErr().expectUint(ErrCode.ERR_STACKING_NOT_AVALIABLE);
+      });
+
+      it("throws ERR_ROUND_FULL error", () => {
+        const result = client.canMineTokens(wallet_2, 1, 10, minersRecFull).result;
+
+        result.expectErr().expectUint(ErrCode.ERR_ROUND_FULL);
+      });
+
+      it("throws ERR_ALREADY_MINED error", () => {
+        const result = client.canMineTokens(wallet_1, 1, 10, minersRec).result;
+
+        result.expectErr().expectUint(ErrCode.ERR_ALREADY_MINED);
+      });
+
+      it("throws ERR_CANNOT_MINE error", () => {
+        const result = client.canMineTokens(wallet_3, 1, 0, minersRec).result;
+
+        result.expectErr().expectUint(ErrCode.ERR_CANNOT_MINE);
+      });
+
+      it("throws ERR_INSUFFICIENT_BALANCE error", () => {
+        const result = client.canMineTokens(wallet_3, 1, wallet_3.balance + 1, minersRec).result;
+
+        result.expectErr().expectUint(ErrCode.ERR_INSUFFICIENT_BALANCE);
+      });
+    });
+
+    describe("can-stack-tokens()", () => {
+      it("throws ERR_CANNOT_STACK error if nowStacksHeight < startStacksHeight", () => {
+        const nowStacksHeight = 3;
+        const startStacksHeight = 2;
+
+        const result = client.canStackTokens(wallet_1, 100, nowStacksHeight, startStacksHeight, 1).result;
+
+        result.expectErr().expectUint(ErrCode.ERR_CANNOT_STACK);
+      });
+
+      it("throws ERR_CANNOT_STACK error if lockPeriod=0 or lockPeriod > max-reward-cycles (32)", () => {
+        const nowStacksHeight = 502;
+        const startStacksHeight = 510;
+
+        const results = [
+          client.canStackTokens(wallet_1, 100, nowStacksHeight, startStacksHeight, 0).result,
+          client.canStackTokens(wallet_1, 100, nowStacksHeight, startStacksHeight, 33).result,
+        ]
+
+        results.forEach((result) => {
+          result.expectErr().expectUint(ErrCode.ERR_CANNOT_STACK);
+        })
+      });
+
+      it("throws ERR_CANNOT_STACK error if amoutToken = 0", () => {
+        const nowStacksHeight = 502;
+        const startStacksHeight = 510;
+        const amountToken = 0;
+
+        const result = client.canStackTokens(wallet_1, amountToken, nowStacksHeight, startStacksHeight, 1).result;
+
+        result.expectErr().expectUint(ErrCode.ERR_CANNOT_STACK);
+      });
+
+      it("throws ERR_INSUFFICIENT_BALANCE if stacker doesn't have enough tokens", () => {
+        const nowStacksHeight = 2;
+        const startStacksHeight = 3;
+        const amountToken = 100000;
+
+        const result = client.canStackTokens(wallet_1, amountToken, nowStacksHeight, startStacksHeight, 1).result;
+
+        result.expectErr().expectUint(ErrCode.ERR_INSUFFICIENT_BALANCE);
+      });
+    });
+
+    describe("get-entitled-stacking-reward()", () => {
+      setupCleanEnv();
+
+      it("returns 0", () => {
+        const stacker = wallet_1;
+        const targetRewardCycle = 0
+        const currentBlockHeight = 0;
+
+        const result = client.getEntitledStackingReward(stacker, targetRewardCycle, currentBlockHeight).result;
+
+        result.expectUint(0);
+      });
+
+      it("returns 1000 if miners commited only 1000ustx and there is only one stacker", () => {
+        const stacker = wallet_1;
+        const miner = wallet_2;
+        const minerCommitment = 1000;
+        const targetRewardCycle = 1;
+
+        // add tokens and stack them at the next cycle
+        chain.mineBlock([
+          client.ftMint(5000, stacker),
+          client.stackTokens(5000, 5, targetRewardCycle, stacker),
+        ]);
+
+        // move chain forward to jump into 1st staking cycle
+        chain.mineEmptyBlock(500);
+
+        // mine some tokes
+        chain.mineBlock([
+          client.mineTokens(minerCommitment, miner)
+        ]);
+
+        // move chain forward to jump into 2nd staking cycle
+        const block = chain.mineEmptyBlock(500);
+
+        const result = client.getEntitledStackingReward(stacker, targetRewardCycle, block.block_height).result;
+
+        result.expectUint(minerCommitment);
+      });
+    });
+
+    describe("get-reward-cycle()", () => {
+      it("returns None if stacksBlockHeight is equal 0", () => {
+        const result = client.getRewardCycle(0).result;
+
+        result.expectNone()
+      });
+
+      it("returns Some with correct value when stacksBlockHeight > 0", () => {
+        const blockHeights = [1, 5, 499, 500, 501, 1001];
+
+        blockHeights.forEach((stacksBlockHeight) => {
+          const expectedValue = Math.floor((stacksBlockHeight - FIRST_STACKING_BLOCK) / REWARD_CYCLE_LENGTH);
+
+          const result = client.getRewardCycle(stacksBlockHeight).result;
+
+          result.expectSome().expectUint(expectedValue);
+        });
+      });
+    });
+
+    describe("get-first-block-height-in-reward-cycle", () => {
+      it("returns correct value", () => {
+        const rewardCycles = [0, 1, 2, 3, 5, 15, 24, 44, 890];
+
+        rewardCycles.forEach((rewardCycle) => {
+          const expectedValue = FIRST_STACKING_BLOCK + (REWARD_CYCLE_LENGTH * rewardCycle);
+
+          const result = client.getFirstBlockHeightInRewardCycle(rewardCycle).result;
+
+          result.expectUint(expectedValue);
+        });
       });
     });
   });


### PR DESCRIPTION
This PR introduces more Clarinet-based tests that covers read-only and public functions.

Only `claim-token-reward` is not covered with tests, because I don't know if it is possible to control what `(get-block-info? vrf-seed stacks-block)` will return, therefore I can't create stable tests for it. 