### PR TITLE
feat: add mining activation threshold and miners registration

### DIFF
--- a/contracts/citycoin.clar
+++ b/contracts/citycoin.clar
@@ -14,7 +14,7 @@
 (define-constant ERR-NOTHING-TO-REDEEM u10)
 (define-constant ERR-CANNOT-MINE u11)
 (define-constant ERR-MINER-ALREADY-REGISTERED u12)
-(define-constant ERR-MINING-ACTIVATION-TRESHOLD-REACHED u13)
+(define-constant ERR-MINING-ACTIVATION-THRESHOLD-REACHED u13)
 
 ;; Tailor to your needs.
 (define-constant TOKEN-REWARD-MATURITY u100)        ;; how long a miner must wait before claiming their minted tokens
@@ -139,7 +139,7 @@
 ;; The fungible token that can be Stacked.
 (define-fungible-token citycoins)
 
-(define-constant MINING-ACTIVATION-TRESHOLD u1)  ;; how many miners have to register to kickoff countdown to mining activation
+(define-constant MINING-ACTIVATION-TRHESHOLD u1)  ;; how many miners have to register to kickoff countdown to mining activation
 (define-constant MINING-ACTIVATION-DELAY u100)   ;; how many blocks after last miner registration mining will be activated   
 
 (define-data-var signalingMinersNonce uint u0)
@@ -157,8 +157,8 @@
         (asserts! (is-none (map-get? SignalingMiners {miner: tx-sender}))
             (err ERR-MINER-ALREADY-REGISTERED))
 
-        (asserts! (<= newId MINING-ACTIVATION-TRESHOLD)
-            (err ERR-MINING-ACTIVATION-TRESHOLD-REACHED))
+        (asserts! (<= newId MINING-ACTIVATION-THRESHOLD)
+            (err ERR-MINING-ACTIVATION-THRESHOLD-REACHED))
         
         (map-set SignalingMiners
             {miner: tx-sender}
@@ -167,7 +167,7 @@
         
         (var-set signalingMinersNonce newId)
 
-        (if (is-eq newId MINING-ACTIVATION-TRESHOLD) 
+        (if (is-eq newId MINING-ACTIVATION-THRESHOLD) 
             (begin
                 (var-set first-stacking-block (+ block-height MINING-ACTIVATION-DELAY))
                 (ok true)


### PR DESCRIPTION
This PR adds mechanism that will allow activate with delay mining process based on miners registration.

`MINING-ACTIVATION-THRESHOLD` - stores how many miners have to register in order to start countdown until mining activation
`MINING-ACTIVATION-DELAY` - stores how many blocks after last miner registration mining will be activated

Miners who wish to signal their willingness to mine must call `register-miner` function.
Each miner can register only once.
Mechanism allows to register up to `MINING-ACTIVATION-THRESHOLD` miners. Once threshold is reached all new registrations will be discarded.

`FIRST-STACKING-BLOCK` is initially set to highest possible value - thanks to that we'll sure that users won't be able to mine prior mining activation. 

We are storing every single registration, so in theory we could reward miners who help activate mining process and allow them to withdraw small amount of tokens. 

Once https://github.com/citycoins/citycoin/pull/27 will be merged I'll add test suite to this subject.

---
close  #15