### PR TITLE
Optimize mine-tokens execution costs

### DIFF
--- a/contracts/citycoin.clar
+++ b/contracts/citycoin.clar
@@ -135,6 +135,11 @@
     }
 )
 
+(define-map miners-block-commitment
+    { miner: principal, stacks-block-height: uint }
+    { committed: bool }
+)
+
 ;; How many uSTX are mined per reward cycle, and how many tokens are locked up in the same reward cycle.
 (define-map tokens-per-cycle
     { reward-cycle: uint }
@@ -352,27 +357,11 @@
         none))
 )
 
-;; Inner fold function for finding a given miner in a list of miners.
-(define-private (has-mined-in-list-closure (idx uint) (input { found: bool, candidate: principal, miners: (list 32 { miner: principal, amount-ustx: uint }) }))
-    (let (
-        (already-found (get found input))
-        (miner-candidate (get candidate input))
-        (miners-list (get miners input))
-    )
-    {
-        found: (match (element-at miners-list idx)
-                       miner-rec (or already-found (is-eq miner-candidate (get miner miner-rec)))
-                       already-found),
-        candidate: miner-candidate,
-        miners: miners-list
-    })
-)
-
-;; Determine if a given miner has already mined in a list of miners.
-(define-read-only (has-mined-in-list (miner principal) (miner-list (list 32 { miner: principal, amount-ustx: uint })))
-    (get found
-        (fold has-mined-in-list-closure REWARD-CYCLE-INDEXES
-            { found: false, candidate: miner, miners: miner-list }))
+;; Determine if a given miner has already mined at given block height
+(define-read-only (has-mined (miner principal) (stacks-block-height uint))
+    (is-some (map-get? miners-block-commitment 
+        { miner: miner, stacks-block-height: stacks-block-height }
+    ))
 )
 
 ;; Determine whether or not the given principal can claim the mined tokens at a particular block height,
@@ -448,7 +437,7 @@
         (asserts! (< (len (get miners miners-rec)) u32)
             (err ERR-ROUND-FULL))
 
-        (asserts! (not (has-mined-in-list miner-id (get miners miners-rec)))
+        (asserts! (not (has-mined miner-id stacks-bh))
             (err ERR-ALREADY-MINED))
 
         (asserts! (> amount-ustx u0)
@@ -539,6 +528,10 @@
                 miners: (unwrap-panic (as-max-len? (append (get miners miner-rec) { miner: miner-id, amount-ustx: commit-ustx }) u32)),
                 claimed: false
             }
+        )
+        (map-set miners-block-commitment
+            { miner: miner-id, stacks-block-height: stacks-bh}
+            { committed: true }
         )
         (map-set tokens-per-cycle
             { reward-cycle: rc }

--- a/src/citycoin-client.ts
+++ b/src/citycoin-client.ts
@@ -121,12 +121,12 @@ export class CityCoinClient {
     )
   }
 
-  hasMinedInList(miner: Account, miners: MinersList): Result {
+  hasMined(miner: Account, blockHeight: number): Result {
     return this.callReadOnlyFn(
-      "has-mined-in-list",
+      "has-mined",
       [
         types.principal(miner.address),
-        miners.convert()
+        types.uint(blockHeight)
       ]
     );
   }

--- a/tests/citycoin_test.ts
+++ b/tests/citycoin_test.ts
@@ -111,6 +111,10 @@ describe('[CityCoin]', () => {
     });
 
     describe("get-total-supply()", () => {
+      beforeEach(() => {
+        setupCleanEnv();
+      })
+
       it("should return 0", () => {
         const result = client.getTotalSupply().result;
 
@@ -244,21 +248,30 @@ describe('[CityCoin]', () => {
       });
     });
 
-    describe("has-mined-in-list()", () => {
-      const miners = new MinersList();
-      miners.push(
-        { miner: wallet_1, amountUstx: 1 },
-        { miner: wallet_2, amountUstx: 2 },
-      );
+    describe("has-mined()", () => {
+      setupCleanEnv();
+      
+      // activate mining
+      chain.mineBlock([
+        client.registerMiner(wallet_3)
+      ]);
 
-      it("returns true if miner is in a list", () => {
-        const result = client.hasMinedInList(wallet_2, miners).result;
+      // advance chain to block where mining is active
+      const block = chain.mineEmptyBlock(MINING_ACTIVATION_DELAY);
+      const blockHeight = block.block_height;
+    
+      it("returns true if miner mined selected block", () => {
+        chain.mineBlock([
+          client.mineTokens(200, wallet_1)
+        ]);
+        
+        const result = client.hasMined(wallet_1, blockHeight).result;
 
         result.expectBool(true);
       })
 
-      it("returns false if miner is not in a list", () => {
-        const result = client.hasMinedInList(wallet_3, miners).result;
+      it("returns false if miner didn't mine selected block", () => {
+        const result = client.hasMined(wallet_2, blockHeight).result;
 
         result.expectBool(false);
       });
@@ -373,9 +386,11 @@ describe('[CityCoin]', () => {
         chain.mineBlock([
           client.registerMiner(wallet_3)
         ]);
-        const block = chain.mineEmptyBlock(MINING_ACTIVATION_DELAY);
+        chain.mineEmptyBlock(MINING_ACTIVATION_DELAY);
 
-        const result = client.canMineTokens(wallet_1, block.block_height, 10, minersRec).result;
+        const block = chain.mineBlock([client.mineTokens(200, wallet_1)]);
+
+        const result = client.canMineTokens(wallet_1, block.height-1, 10, minersRec).result;
 
         result.expectErr().expectUint(ErrCode.ERR_ALREADY_MINED);
       });

--- a/tests/test-poxl.clar
+++ b/tests/test-poxl.clar
@@ -105,22 +105,21 @@
     ))
 )
 
-(define-private (test-has-mined-in-list)
-    (let (
-        (miners-list
-            (unwrap-panic (as-max-len? (list
-                { miner: 'SP1GYBXAJSEF8SY0ERKA068J93E3EGNTXHR98MM5P, amount-ustx: u1 }
-                { miner: 'SP2M85H4NNNPQB0Y7GHT3K5EHWMRZWTHF2QAY1W69, amount-ustx: u2 }
-                { miner: 'SP3A33QYJK76BCDJJD11RYWZP9D62PVQXK2VF5TJN, amount-ustx: u3 }
-            ) u32))))
+(define-private (test-has-mined)
     (begin
-        (print "test-has-mined-in-list")
+        (print "test-has-mined")
 
-        (asserts! (has-mined-in-list 'SP1GYBXAJSEF8SY0ERKA068J93E3EGNTXHR98MM5P miners-list) (err u0))
-        (asserts! (not (has-mined-in-list 'SP1G6P9VD2E455SB0KKSJN0711S1MGH5GXPN4RJ1E miners-list)) (err u0))
+        ;; arrange 
+        (map-set miners-block-commitment 
+            { miner: 'SP1GYBXAJSEF8SY0ERKA068J93E3EGNTXHR98MM5P, stacks-block-height: u10 }
+            { committed: true }
+        )
+
+        (asserts! (has-mined 'SP1GYBXAJSEF8SY0ERKA068J93E3EGNTXHR98MM5P u10) (err u0))
+        (asserts! (not (has-mined 'SP1G6P9VD2E455SB0KKSJN0711S1MGH5GXPN4RJ1E u10)) (err u0))
 
         (ok u0)
-    ))
+    )
 )
 
 (define-private (test-can-claim-tokens)
@@ -214,6 +213,11 @@
         (print "test-can-mine-tokens")
         (asserts! (is-eq (err ERR-STACKING-NOT-AVAILABLE) (can-mine-tokens 'SP1GYBXAJSEF8SY0ERKA068J93E3EGNTXHR98MM5P u0 u0 miners-rec)) (err u0))
         (asserts! (is-eq (err ERR-ROUND-FULL) (can-mine-tokens 'SP1GYBXAJSEF8SY0ERKA068J93E3EGNTXHR98MM5P u10 u0 full-miners-rec)) (err u1))
+        ;; arrange for next assert
+        (map-set miners-block-commitment 
+            { miner: 'SP1GYBXAJSEF8SY0ERKA068J93E3EGNTXHR98MM5P, stacks-block-height: u10 }
+            { committed: true }
+        )
         (asserts! (is-eq (err ERR-ALREADY-MINED) (can-mine-tokens 'SP1GYBXAJSEF8SY0ERKA068J93E3EGNTXHR98MM5P u10 u0 miners-rec)) (err u2))
         (asserts! (is-eq (err ERR-CANNOT-MINE) (can-mine-tokens 'SPT00VPT4EXCMMET7RPFRAHSA86CF6QCY2254J9Q u10 u0 miners-rec)) (err u3))
         (asserts! (is-eq (err ERR-INSUFFICIENT-BALANCE) (can-mine-tokens 'SPP5ERW9P30ZQ9S7KGEBH042E7EJHWDT2Z5K086D u10 u1001 miners-rec)) (err u4))
@@ -381,7 +385,7 @@
         (try! (test-lower-16-le))
         (try! (test-get-block-commit-total))
         (try! (test-get-block-winner))
-        (try! (test-has-mined-in-list))
+        (try! (test-has-mined))
         (try! (test-can-claim-tokens))
         (try! (test-can-mine-tokens))
         (try! (test-can-stack-tokens))


### PR DESCRIPTION
This PR contains changes that optimize cost of execution `mine-tokens` function.

I replaced very expensive `has-mined-in-list` function that uses `fold` to simulate loop and check if miner already mined in selected block or not, with much faster and least expensive `has-mined` which uses `map-get` to achieve the same result.

As a consequence of this modification I had to introduce new map `miners-block-commitment` which stores information if miner committed anything at specific block height or not.

Execution costs were acquired as follows:
```sh
$ npm run clarinet:console
> (contract-call? .citycoin register-miner)
> ::advance_chain_tip 200
> ::get_costs (contract-call? .citycoin mine-tokens u200)
```

**BEFORE**
```
+----------------------+-----------+------------+
|                      | Consumed  | Limit      |
+----------------------+-----------+------------+
| Runtime              | 316336000 | 5000000000 |
+----------------------+-----------+------------+
| Read count           | 17        | 7750       |
+----------------------+-----------+------------+
| Read length (bytes)  | 45591     | 100000000  |
+----------------------+-----------+------------+
| Write count          | 3         | 7750       |
+----------------------+-----------+------------+
| Write length (bytes) | 6875      | 15000000   |
+----------------------+-----------+------------+
```

**AFTER**
```
+----------------------+----------+------------+
|                      | Consumed | Limit      |
+----------------------+----------+------------+
| Runtime              | 61794000 | 5000000000 |
+----------------------+----------+------------+
| Read count           | 19       | 7750       |
+----------------------+----------+------------+
| Read length (bytes)  | 45365    | 100000000  |
+----------------------+----------+------------+
| Write count          | 4        | 7750       |
+----------------------+----------+------------+
| Write length (bytes) | 7122     | 15000000   |
+----------------------+----------+------------+
```

Overall this change reduced `mine-tokens` execution costs  ~5.11x.

@jcnelson if you'll have a time, I would love to hear your opinion about changes like this. Do you see any potential issues they might cause?