### PR TITLE
Fix broken `can-mine-tokens` interfact between js and clarity

### DIFF
--- a/src/citycoin-client.ts
+++ b/src/citycoin-client.ts
@@ -202,14 +202,16 @@ export class CityCoinClient {
   }
 
   canMineTokens(
-    minerId: Account,
+    miner: Account,
+    minerId: number,
     stacksBlockHeight: number,
     amountUstx: number,
   ): Result {
     return this.callReadOnlyFn(
       "can-mine-tokens",
       [
-        types.principal(minerId.address),
+        types.principal(miner.address),
+        types.uint(minerId),
         types.uint(stacksBlockHeight),
         types.uint(amountUstx)
       ]


### PR DESCRIPTION
This PR contains changes that fix broken `can-mine-tokens` interface between JS and clarity.