### PR TITLE
Feat/data structure remodel

### DIFF
--- a/contracts/citycoin.clar
+++ b/contracts/citycoin.clar
@@ -472,7 +472,7 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
             (asserts! (not (get claimed block))
                 (err ERR-ALREADY-CLAIMED))
 
-            (match (get-block-winner claimer-stacks-block-height random-sample (get-miners-at-block claimer-stacks-block-height))
+            (match (get-block-winner claimer-stacks-block-height random-sample)
                 winner-rec (if (is-eq claimer-id (get miner-id winner-rec))
                                (ok true)
                                (err ERR-UNAUTHORIZED))

--- a/contracts/citycoin.clar
+++ b/contracts/citycoin.clar
@@ -799,10 +799,12 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
 ;; wait for a token maturity window in order to obtain the tokens.  Once that window passes, they can get the tokens.
 ;; This ensures that no one knows the VRF seed that will be used to pick the winner.
 (define-public (mine-tokens (amount-ustx uint))
-    (let (
-        (miner-id (get-or-create-miner-id tx-sender))
+    (mine-tokens-at-block block-height (get-or-create-miner-id tx-sender) amount-ustx)
+)
 
-        (rc (unwrap! (get-reward-cycle block-height)
+(define-private (mine-tokens-at-block (stacks-block-height uint) (miner-id uint) (amount-ustx uint))
+    (let (
+        (rc (unwrap! (get-reward-cycle stacks-block-height)
             (err ERR-STACKING-NOT-AVAILABLE)))
         (total-stacked (get total-tokens (map-get? tokens-per-cycle { reward-cycle: rc })))
         (total-stacked-ustx (default-to u0 total-stacked))
@@ -820,11 +822,9 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
             )
         )
     )
-
     (begin
-        (try! (can-mine-tokens tx-sender miner-id block-height amount-ustx))
-
-        (try! (set-tokens-mined tx-sender miner-id block-height amount-ustx amount-ustx-to-stacker amount-ustx-to-city))
+        (try! (can-mine-tokens tx-sender miner-id stacks-block-height amount-ustx))
+        (try! (set-tokens-mined tx-sender miner-id stacks-block-height amount-ustx amount-ustx-to-stacker amount-ustx-to-city))
 
         ;; check if stacking is active
         (if stacked-something

--- a/contracts/test_addons/citycoin.clar
+++ b/contracts/test_addons/citycoin.clar
@@ -228,3 +228,12 @@
 (define-public (set-mining-activation-threshold (new-threshold uint))
   (ok (var-set mining-activation-threshold new-threshold))
 )
+
+
+(define-public (activate-mining)
+  (begin
+    (var-set city-wallet 'STFCVYY1RJDNJHST7RRTPACYHVJQDJ7R1DWTQHQA)
+    (var-set mining-activation-threshold u1)
+    (register-miner)
+  )
+)

--- a/src/citycoin-client.ts
+++ b/src/citycoin-client.ts
@@ -146,13 +146,12 @@ export class CityCoinClient {
     );
   }
 
-  getBlockWinner(stacksBlockHeight: number, randomSampleUint: number, miners: MinersList): Result {
+  getBlockWinner(stacksBlockHeight: number, randomSampleUint: number): Result {
     return this.callReadOnlyFn(
       "get-block-winner",
       [
         types.uint(stacksBlockHeight),
         types.uint(randomSampleUint),
-        miners.convert()
       ]
     )
   }
@@ -197,7 +196,7 @@ export class CityCoinClient {
     claimer: Account,
     claimerStacksBlockHeight: number,
     randomSample: number,
-    minersRec: MinersRec,
+    minedBlock: MinedBlock,
     currentStacksBlock: number
   ): Result {
     return this.callReadOnlyFn(
@@ -206,7 +205,7 @@ export class CityCoinClient {
         types.principal(claimer.address),
         types.uint(claimerStacksBlockHeight),
         types.uint(randomSample),
-        minersRec.convert(),
+        minedBlock.convert(),
         types.uint(currentStacksBlock)
       ]
     );
@@ -405,6 +404,31 @@ export class CityCoinClient {
   }
 }
 
+export class MinedBlock {
+
+  minersCount: number;
+  leastCommitmentIdx: number;
+  leastCommitmentUstx: number;
+  claimed: boolean;
+
+  constructor(minersCount: number, leastCommitmentIdx: number, leastCommitmentUstx: number, claimed: boolean) {
+    this.minersCount = minersCount;
+    this.leastCommitmentIdx = leastCommitmentIdx;
+    this.leastCommitmentUstx = leastCommitmentUstx;
+    this.claimed = claimed;
+  }
+
+  convert(): string {
+    return types.tuple({
+      "miners-count": types.uint(this.minersCount),
+      "least-commitment-idx": types.uint(this.leastCommitmentIdx),
+      "least-commitment-ustx": types.uint(this.leastCommitmentUstx),
+      "claimed": types.bool(this.claimed)
+    })
+  }
+
+}
+
 export interface MinerCommit {
   miner: Account,
   minerId: number,
@@ -431,7 +455,7 @@ export class MinersList extends Array<MinerCommit> {
     let item = this[index];
     return {
       "miner-id": types.uint(item.minerId),
-      "amount-ustx": types.uint(item.amountUstx)
+      "ustx": types.uint(item.amountUstx)
     }
   }
 }

--- a/tests/citycoin_test.ts
+++ b/tests/citycoin_test.ts
@@ -12,7 +12,7 @@ import {
 import {
   CityCoinClient,
   MinersList,
-  MinersRec,
+  MinedBlock,
   ErrCode,
   FIRST_STACKING_BLOCK,
   REWARD_CYCLE_LENGTH,
@@ -444,7 +444,7 @@ describe('[CityCoin]', () => {
         setupCleanEnv();
         chain.mineBlock([
           client.setMiningActivationThreshold(1),
-          client.registerMiner(wallet_3)
+          client.registerMiner(wallet_1)
         ]);
         const block = chain.mineEmptyBlock(MINING_ACTIVATION_DELAY);
 
@@ -466,7 +466,7 @@ describe('[CityCoin]', () => {
         const known_rnd_winners = [0, 1, 1, 2, 2, 2, 0, 1, 1, 2, 2, 2, 0]
 
         known_rnd_winners.forEach((e, i) => {
-          let result = client.getBlockWinner(block.block_height, i, miners).result;
+          let result = client.getBlockWinner(block.block_height, i).result;
           let winner = result.expectSome().expectTuple();
           let expectedWinner = miners.getFormatted(e)
 
@@ -475,7 +475,7 @@ describe('[CityCoin]', () => {
       });
 
       it("should return no winner if there are no miners", () => {
-        const result = client.getBlockWinner(200, 0, new MinersList()).result;
+        const result = client.getBlockWinner(200, 0).result;
 
         result.expectNone();
       });
@@ -527,8 +527,8 @@ describe('[CityCoin]', () => {
         txs.push(client.mineTokens(r.amountUstx, r.miner));
       });
       
-      const claimedRec = new MinersRec(miners, true, miners[0]);
-      const unclaimedRec = new MinersRec(miners, false, undefined);
+      const claimedBlock = new MinedBlock(3, 1, 1, true);
+      const unclaimedBlock = new MinedBlock(3, 1, 1, false);
       const tokenRewardMaturity = 100;
 
 
@@ -545,13 +545,13 @@ describe('[CityCoin]', () => {
         const currentStacksBlock = block.block_height + tokenRewardMaturity + 1;
 
         const results = [
-          client.canClaimTokens(wallet_1, claimerStacksBlockHeight, 0, unclaimedRec, currentStacksBlock).result,
-          client.canClaimTokens(wallet_2, claimerStacksBlockHeight, 1, unclaimedRec, currentStacksBlock).result,
-          client.canClaimTokens(wallet_2, claimerStacksBlockHeight, 2, unclaimedRec, currentStacksBlock).result,
-          client.canClaimTokens(wallet_3, claimerStacksBlockHeight, 3, unclaimedRec, currentStacksBlock).result,
-          client.canClaimTokens(wallet_3, claimerStacksBlockHeight, 4, unclaimedRec, currentStacksBlock).result,
-          client.canClaimTokens(wallet_3, claimerStacksBlockHeight, 5, unclaimedRec, currentStacksBlock).result,
-          client.canClaimTokens(wallet_1, claimerStacksBlockHeight, 6, unclaimedRec, currentStacksBlock).result,
+          client.canClaimTokens(wallet_1, claimerStacksBlockHeight, 0, unclaimedBlock, currentStacksBlock).result,
+          client.canClaimTokens(wallet_2, claimerStacksBlockHeight, 1, unclaimedBlock, currentStacksBlock).result,
+          client.canClaimTokens(wallet_2, claimerStacksBlockHeight, 2, unclaimedBlock, currentStacksBlock).result,
+          client.canClaimTokens(wallet_3, claimerStacksBlockHeight, 3, unclaimedBlock, currentStacksBlock).result,
+          client.canClaimTokens(wallet_3, claimerStacksBlockHeight, 4, unclaimedBlock, currentStacksBlock).result,
+          client.canClaimTokens(wallet_3, claimerStacksBlockHeight, 5, unclaimedBlock, currentStacksBlock).result,
+          client.canClaimTokens(wallet_1, claimerStacksBlockHeight, 6, unclaimedBlock, currentStacksBlock).result,
         ];
 
         results.forEach((result) => {
@@ -572,9 +572,9 @@ describe('[CityCoin]', () => {
         const currentStacksBlock = block.block_height + tokenRewardMaturity + 1;
 
         const results = [
-          client.canClaimTokens(wallet_4, claimerStacksBlockHeight, 0, unclaimedRec, currentStacksBlock).result,
-          client.canClaimTokens(wallet_5, claimerStacksBlockHeight, 1, unclaimedRec, currentStacksBlock).result,
-          client.canClaimTokens(wallet_6, claimerStacksBlockHeight, 2, unclaimedRec, currentStacksBlock).result,
+          client.canClaimTokens(wallet_4, claimerStacksBlockHeight, 0, unclaimedBlock, currentStacksBlock).result,
+          client.canClaimTokens(wallet_5, claimerStacksBlockHeight, 1, unclaimedBlock, currentStacksBlock).result,
+          client.canClaimTokens(wallet_6, claimerStacksBlockHeight, 2, unclaimedBlock, currentStacksBlock).result,
         ]
 
         results.forEach((result) => {
@@ -583,14 +583,14 @@ describe('[CityCoin]', () => {
       });
 
       it("throws ERR_IMMATURE_TOKEN_REWARD", () => {
-        const result = client.canClaimTokens(wallet_1, 0, 0, unclaimedRec, tokenRewardMaturity).result;
+        const result = client.canClaimTokens(wallet_1, 0, 0, unclaimedBlock, tokenRewardMaturity).result;
 
         result.expectErr().expectUint(ErrCode.ERR_IMMATURE_TOKEN_REWARD);
       });
 
       it("throws ERR_ALREADY_CLAIMED error", () => {
         const currentStacksBlock = tokenRewardMaturity + 1;
-        const result = client.canClaimTokens(wallet_1, 0, 0, claimedRec, currentStacksBlock).result;
+        const result = client.canClaimTokens(wallet_1, 0, 0, claimedBlock, currentStacksBlock).result;
 
         result.expectErr().expectUint(ErrCode.ERR_ALREADY_CLAIMED);
       });


### PR DESCRIPTION
This PR changes how we store information about signaling-miners and miners commitments.

`signaling-miners`  has been merged with `miners` map as they both had exactly the same data structure.

Right now `mined-blocks` map stores only crucial information about specific blocks.
Miners commitment have been moved to new map `blocks-miners` that uses block height and `idx` as key. `idx` is just an incremented numeric value from 1 to 128, where 128 is maximum allowed miners per block. This value is incremented with each new commitment.

Thanks to that execution costs of first 128 calls (per block) of `mine-tokens` is the same and is very low as logic of these calls can be boiled down to calling `map-set` to add new element to map.
Once we reach 128 miners in bock, adding any additional one in that block is a bit more expensive as we have to push out of the list miner who committed the least, replace it with new one and find new miner who committed the least.
Replacing is done in place, however finding new who committed the least has to be done by looping over all 128 miners.


Main drawback of this change is that it increases execution costs of `claim-token-reward`.
