### PR TITLE
Add optional memo to mine-tokens function

### DIFF
--- a/contracts/citycoin.clar
+++ b/contracts/citycoin.clar
@@ -798,8 +798,14 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
 ;; and in doing so, enters their candidacy to be able to claim the block reward (via claim-token-reward).  The miner must 
 ;; wait for a token maturity window in order to obtain the tokens.  Once that window passes, they can get the tokens.
 ;; This ensures that no one knows the VRF seed that will be used to pick the winner.
-(define-public (mine-tokens (amount-ustx uint))
-    (mine-tokens-at-block block-height (get-or-create-miner-id tx-sender) amount-ustx)
+(define-public (mine-tokens (amount-ustx uint) (memo (optional (buff 34))))
+    (begin
+        (if (is-some memo)
+            (print memo)
+            none
+        )
+        (mine-tokens-at-block block-height (get-or-create-miner-id tx-sender) amount-ustx)
+    )
 )
 
 (define-private (mine-tokens-at-block (stacks-block-height uint) (miner-id uint) (amount-ustx uint))

--- a/src/citycoin-client.ts
+++ b/src/citycoin-client.ts
@@ -304,12 +304,21 @@ export class CityCoinClient {
     );
   }
 
-  mineTokens(amountUstx: number, sender: Account): Tx {
+  mineTokens(amountUstx: number, sender: Account, memo: ArrayBuffer|undefined = undefined): Tx {
+    let memoVal: string;
+
+    if ( typeof memo == "undefined" ) {
+      memoVal = types.none();
+    } else {
+      memoVal = types.some(types.buff(memo));
+    }
+
     return Tx.contractCall(
       this.contractName,
       "mine-tokens",
       [
-        types.uint(amountUstx)
+        types.uint(amountUstx),
+        memoVal
       ],
       sender.address
     );

--- a/tests/citycoin_test.ts
+++ b/tests/citycoin_test.ts
@@ -1011,6 +1011,31 @@ describe('[CityCoin]', () => {
           wallet_6.address
         );
       });
+
+      it("emits print event with memo if supplied", () => {
+        chain.mineBlock([
+          client.setCityWallet(wallet_6)
+        ]);
+
+        const memo = new TextEncoder().encode("hello world");
+
+        const block = chain.mineBlock([
+          client.mineTokens(200, wallet_1, memo)
+        ]);
+
+        const expectedEvent = {
+          type: "contract_event", 
+          contract_event: {
+            contract_identifier: client.getContractAddress(),
+            topic: "print",
+            value: types.some(types.buff(memo))
+          }
+        }
+
+        const receipt = block.receipts[0];
+        assertEquals(receipt.events.length, 2);
+        assertEquals(receipt.events[0], expectedEvent);
+      });
     });
 
     describe("claim-stacking-reward()", () => {


### PR DESCRIPTION
This PR adds optional memo field to `mine-tokens` function that allows miners to attach custom 34 bytes long message to their mining transaction.

Memo length is set to 34 bytes, to keep it consistent with memo's used in other functions.

close #29 