### PR TITLE
Allow owner to change token uri to new one or none

### DIFF
--- a/contracts/citycoin.clar
+++ b/contracts/citycoin.clar
@@ -1,5 +1,5 @@
 ;; citycoin implementation of the PoX-lite contract, MVP.
-
+(define-constant CONTRACT-OWNER tx-sender)
 ;; error codes
 (define-constant ERR-NO-WINNER u0)
 (define-constant ERR-NO-SUCH-MINER u1)
@@ -63,6 +63,15 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
     0xe0 0xe1 0xe2 0xe3 0xe4 0xe5 0xe6 0xe7 0xe8 0xe9 0xea 0xeb 0xec 0xed 0xee 0xef
     0xf0 0xf1 0xf2 0xf3 0xf4 0xf5 0xf6 0xf7 0xf8 0xf9 0xfa 0xfb 0xfc 0xfd 0xfe 0xff
 ))
+
+(define-data-var token-uri (optional (string-utf8 256)) (some u"https://cdn.citycoins.co/metadata/citycoin.json"))
+
+(define-public (set-token-uri (new-uri (optional (string-utf8 256))))
+    (begin
+        (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR-UNAUTHORIZED))
+        (ok (var-set token-uri new-uri))
+    )
+)
 
 ;; Convert a 1-byte buffer into its uint representation.
 (define-private (buff-to-u8 (byte (buff 1)))
@@ -979,4 +988,4 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
     (ok (ft-get-supply citycoins)))
 
 (define-read-only (get-token-uri)
-    (ok (some u"https://cdn.citycoins.co/metadata/citycoin.json")))
+    (ok (var-get token-uri)))

--- a/src/citycoin-client.ts
+++ b/src/citycoin-client.ts
@@ -380,6 +380,25 @@ export class CityCoinClient {
     return this.callReadOnlyFn("get-total-supply-ustx");
   }
 
+  setTokenUri(sender: Account, newUri?:string|undefined): Tx {
+    let newUriVal: string;
+
+    if ( typeof newUri == "undefined" ) {
+      newUriVal = types.none();
+    } else {
+      newUriVal = types.some(types.utf8(newUri));
+    }
+
+    return Tx.contractCall(
+      this.contractName,
+      "set-token-uri",
+      [
+        newUriVal
+      ],
+      sender.address
+    )
+  }
+
   // SIP-010 functions
 
   transfer(amount: number, from: Account, to: Account, sender: Account): Tx {

--- a/tests/citycoin_test.ts
+++ b/tests/citycoin_test.ts
@@ -170,7 +170,7 @@ describe('[CityCoin]', () => {
     });
 
     describe("get-token-uri()", () => {
-      it("should return none", () => {
+      it("should return correct uri", () => {
         const result = client.getTokenUri().result;
 
         result.expectOk().expectSome().expectUtf8("https://cdn.citycoins.co/metadata/citycoin.json");
@@ -1219,7 +1219,44 @@ describe('[CityCoin]', () => {
 
         receipt.result.expectErr().expectUint(ErrCode.ERR_MINING_ACTIVATION_THRESHOLD_REACHED);
         assertEquals(receipt.events.length, 0);
-      })
+      });
+    });
+
+    describe('set-token-uri', () => {
+      it("fails with ERR_UNAUTHORIZED when called by someone who is not contract owner", () => {
+        const block = chain.mineBlock([
+          client.setTokenUri(wallet_3, "http://something-something.com")
+        ]);
+
+        const receipt = block.receipts[0];
+
+        receipt.result.expectErr().expectUint(ErrCode.ERR_UNAUTHORIZED);
+      });
+
+      it("changes token uri to none if no new value is provided", () => {
+        const block = chain.mineBlock([
+          client.setTokenUri(deployer)
+        ]);
+
+        const receipt = block.receipts[0];
+        receipt.result.expectOk().expectBool(true);
+
+        const result = client.getTokenUri().result;
+        result.expectOk().expectNone();
+      });
+
+      it("changes token uri to new value if provided", () => {
+        const newUri = "http://something-something.com"
+        const block = chain.mineBlock([
+          client.setTokenUri(deployer, newUri)
+        ]);
+
+        const receipt = block.receipts[0];
+        receipt.result.expectOk().expectBool(true);
+
+        const result = client.getTokenUri().result;
+        result.expectOk().expectSome().expectUtf8(newUri);
+      });
     });
   });
 });


### PR DESCRIPTION
This PR introduces new public function `set-token-uri` that allows contract owner and only contract owner to change token uri.

close #42 