### PR TITLE
Allow city wallet owner to change it to new one

### DIFF
--- a/contracts/citycoin.clar
+++ b/contracts/citycoin.clar
@@ -959,6 +959,17 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
     (ok (stx-get-balance (as-contract tx-sender)))
 )
 
+(define-read-only (get-city-wallet)
+    (var-get city-wallet)
+)
+
+(define-public (set-city-wallet (wallet-address principal))
+  (begin
+    (asserts! (is-eq tx-sender (var-get city-wallet)) (err ERR-UNAUTHORIZED))
+    (ok (var-set city-wallet wallet-address))
+  )
+)
+
 ;;;;;;;;;;;;;;;;;;;;; SIP 010 ;;;;;;;;;;;;;;;;;;;;;;
 ;; testnet: (impl-trait 'STR8P3RD1EHA8AA37ERSSSZSWKS9T2GYQFGXNA4C.sip-010-trait-ft-standard.sip-010-trait)
 (impl-trait 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait)

--- a/contracts/test_addons/citycoin.clar
+++ b/contracts/test_addons/citycoin.clar
@@ -215,7 +215,7 @@
   )
 )
 
-(define-public (set-city-wallet (wallet-address principal))
+(define-public (set-city-wallet-unsafe (wallet-address principal))
   ;; specify city wallet address for testing, allows for a test wallet
   ;; to be used in place of specific city wallet defined in constant
   (begin

--- a/src/citycoin-client.ts
+++ b/src/citycoin-client.ts
@@ -365,15 +365,30 @@ export class CityCoinClient {
     )
   }
 
-  setCityWallet(sender: Account): Tx {
+  setCityWalletUnsafe(cityWallet: Account): Tx {
+    return Tx.contractCall(
+      this.contractName,
+      "set-city-wallet-unsafe",
+      [
+        types.principal(cityWallet.address)
+      ],
+      this.deployer.address
+    )
+  }
+
+  setCityWallet(cityWallet:Account, sender: Account): Tx {
     return Tx.contractCall(
       this.contractName,
       "set-city-wallet",
       [
-        types.principal(sender.address)
+        types.principal(cityWallet.address)
       ],
       sender.address
     )
+  }
+
+  getCityWallet(): Result {
+    return this.callReadOnlyFn("get-city-wallet");
   }
 
   getTotalSupplyUstx(): Result {


### PR DESCRIPTION
This PR introduces a function `set-city-wallet` that allows city wallet owner and only city wallet owner to change its address to new one.
To complement it `get-city-wallet` has been added as well.

Additionally `set-city-wallet` function used in test add-on has been renamed to `set-city-wallet-unsafe` as it doesn't check who calls it and should be used only in test arrange process.

closes #51 