### PR TITLE
fix: prevent contracts from calling set-city-wallet

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -9,6 +9,11 @@ depends_on = []
 path = "contracts/clarinet/citycoin.clar"
 depends_on = ["sip-010-trait"]
 
+# contracts listed below are used only in test suite
 [contracts.malicious]
 path = "contracts/clarinet/malicious.clar"
+depends_on = ["citycoin"]
+
+[contracts.city_wallet]
+path = "contracts/clarinet/city_wallet.clar"
 depends_on = ["citycoin"]

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -8,3 +8,7 @@ depends_on = []
 [contracts.citycoin]
 path = "contracts/clarinet/citycoin.clar"
 depends_on = ["sip-010-trait"]
+
+[contracts.malicious]
+path = "contracts/clarinet/malicious.clar"
+depends_on = ["citycoin"]

--- a/contracts/city_wallet.clar
+++ b/contracts/city_wallet.clar
@@ -1,0 +1,10 @@
+;; This contract is used only during tests to verify if contract set as a city wallet will be able to change it to different address
+(define-constant CONTRACT_OWNER tx-sender)
+(define-constant ERR_UNAUTHORIZED u401)
+
+(define-public (set-city-wallet (new-wallet principal))
+  (begin
+    (asserts! (is-eq contract-caller CONTRACT_OWNER) (err ERR_UNAUTHORIZED))
+    (contract-call? 'ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE.citycoin set-city-wallet new-wallet)
+  )
+)

--- a/contracts/citycoin.clar
+++ b/contracts/citycoin.clar
@@ -963,11 +963,13 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
     (var-get city-wallet)
 )
 
+;; Update the city-wallet variable
+;; This can only be called by the city-wallet principal.
+;; Calling `set-city-wallet` from an outside contract (that is not the city-wallet principal)
+;; is not allowed
 (define-public (set-city-wallet (wallet-address principal))
   (begin
-    (asserts! (is-eq tx-sender (var-get city-wallet)) (err ERR-UNAUTHORIZED))
-    ;; ensure this cannot be called through another contract
-    (asserts! (is-eq tx-sender contract-caller) (err ERR-UNAUTHORIZED))
+    (asserts! (is-eq contract-caller (var-get city-wallet)) (err ERR-UNAUTHORIZED))
     (ok (var-set city-wallet wallet-address))
   )
 )

--- a/contracts/citycoin.clar
+++ b/contracts/citycoin.clar
@@ -966,6 +966,8 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
 (define-public (set-city-wallet (wallet-address principal))
   (begin
     (asserts! (is-eq tx-sender (var-get city-wallet)) (err ERR-UNAUTHORIZED))
+    ;; ensure this cannot be called through another contract
+    (asserts! (is-eq tx-sender contract-caller) (err ERR-UNAUTHORIZED))
     (ok (var-set city-wallet wallet-address))
   )
 )

--- a/contracts/malicious.clar
+++ b/contracts/malicious.clar
@@ -1,0 +1,4 @@
+
+(define-public (attack)
+  (contract-call? .citycoin set-city-wallet 'STFCVYY1RJDNJHST7RRTPACYHVJQDJ7R1DWTQHQA)
+)

--- a/tests/citycoin_test.ts
+++ b/tests/citycoin_test.ts
@@ -1329,6 +1329,39 @@ describe('[CityCoin]', () => {
         const result = client.getCityWallet().result;
         result.expectPrincipal(newCityWallet.address);
       });
+
+      it("succeeds and sets new city wallet, when called by contract that was a previous city wallet", () => {
+        const cityWallet: Account = {
+          name: 'city_wallet',
+          address: 'ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE.city_wallet',
+          balance: 0,
+          mnemonic: 'unknown',
+          derivation: 'unknown'
+        };
+        const newCityWallet = wallet_3;
+
+        
+        chain.mineBlock([
+          client.setCityWalletUnsafe(cityWallet)
+        ]);
+
+        client.getCityWallet().result.expectPrincipal('ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE.city_wallet');
+
+        const block = chain.mineBlock([
+          Tx.contractCall(
+            'city_wallet', 
+            'set-city-wallet',
+            [
+              types.principal(newCityWallet.address)
+            ],
+            deployer.address
+            )
+        ]);
+
+        const receipt = block.receipts[0];
+        console.info(block)
+        receipt.result.expectOk().expectBool(true);
+      })
     });
   });
 });

--- a/tests/citycoin_test.ts
+++ b/tests/citycoin_test.ts
@@ -1290,6 +1290,27 @@ describe('[CityCoin]', () => {
         result.expectErr().expectUint(ErrCode.ERR_UNAUTHORIZED);
       });
 
+      it("throws ERR_UNAUTHORIZED error when called via contract-call", () => {
+        const cityWallet = wallet_1;
+        
+        chain.mineBlock([
+          client.setCityWalletUnsafe(cityWallet)
+        ]);
+      
+        const block = chain.mineBlock([
+          Tx.contractCall(
+            'malicious',
+            'attack',
+            [],
+            wallet_1.address
+          )
+        ]);
+      
+        const result = block.receipts[0].result;
+      
+        result.expectErr().expectUint(ErrCode.ERR_UNAUTHORIZED);
+      })
+
       it("succeeds and sets new city wallet, when called by previous city wallet", () => {
         const cityWallet = wallet_1;
         const newCityWallet = wallet_3;


### PR DESCRIPTION
It is probably prudent to add a check to ensure that `set-city-wallet` cannot be called through another contract. This vector, although unlikely to be pulled off, could allow a malicious contract to "trick" the city wallet principal into changing the city wallet. Such an action would not be blocked by post conditions.

By default `contract-caller` is set to the same as `tx-sender`. This kind of check is also in `pox.clar`. In the PoX contract, there is a method for allowing only specific contract callers to stack on behalf of a user, but this is likely not necessary for citycoin.

**Warning:** I have not ran tests, as I had issues getting them to run. Thus, there are also no tests for this added check.