### PR TITLE
Fix broken contract and tests after token rename

### DIFF
--- a/contracts/citycoin.clar
+++ b/contracts/citycoin.clar
@@ -572,7 +572,7 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
         (asserts! (> amount-tokens u0)
             (err ERR-CANNOT-STACK))
 
-        (asserts! (<= amount-tokens (ft-get-balance citycoins stacker))
+        (asserts! (<= amount-tokens (ft-get-balance miamicoin stacker))
             (err ERR-INSUFFICIENT-BALANCE))
 
         (ok true)
@@ -949,7 +949,7 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
             { amount-token: u0 })
 
         (try! (as-contract (stx-transfer? entitled-ustx tx-sender stacker)))
-        (try! (as-contract (ft-transfer? citycoins stacked-in-cycle tx-sender stacker)))
+        (try! (as-contract (ft-transfer? miamicoin stacked-in-cycle tx-sender stacker)))
 
         (ok true)
     ))

--- a/contracts/test_addons/citycoin.clar
+++ b/contracts/test_addons/citycoin.clar
@@ -2,7 +2,7 @@
 ;; functions used only during testing
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (define-public (ft-mint (amount uint) (recipient principal))
-  (ft-mint? citycoins amount recipient)
+  (ft-mint? miamicoin amount recipient)
 )
 
 

--- a/src/citycoin-client.ts
+++ b/src/citycoin-client.ts
@@ -26,6 +26,8 @@ export enum ErrCode {
   ERR_TOO_SMALL_COMMITMENT
 }
 
+export const TOKEN_NAME = 'miamicoin';
+export const TOKEN_SYMBOL = 'MIA';
 export const MINING_HALVING_BLOCKS = 210000;
 export const MINING_ACTIVATION_DELAY = 100;
 export const FIRST_STACKING_BLOCK = 1 + MINING_ACTIVATION_DELAY;

--- a/tests/citycoin_test.ts
+++ b/tests/citycoin_test.ts
@@ -19,7 +19,9 @@ import {
   MINING_ACTIVATION_DELAY,
   MINING_HALVING_BLOCKS,
   SPLIT_STACKER_PERCENTAGE,
-  SPLIT_CITY_PERCENTAGE
+  SPLIT_CITY_PERCENTAGE,
+  TOKEN_NAME,
+  TOKEN_SYMBOL
 } from "../src/citycoin-client.ts"
 
 describe('[CityCoin]', () => {
@@ -77,18 +79,18 @@ describe('[CityCoin]', () => {
     });
 
     describe("get-name()", () => {
-      it("should return 'citycoins'", () => {
+      it("should return 'MiamiCoin'", () => {
         const result = client.getName().result;
 
-        result.expectOk().expectAscii("citycoins");
+        result.expectOk().expectAscii("MiamiCoin");
       });
     });
 
     describe("get-symbol()", () => {
-      it("should return 'CYCN'", () => {
+      it(`should return '${TOKEN_SYMBOL}'`, () => {
         const result = client.getSymbol().result;
 
-        result.expectOk().expectAscii("CYCN");
+        result.expectOk().expectAscii(TOKEN_SYMBOL);
       });
     });
 
@@ -894,7 +896,7 @@ describe('[CityCoin]', () => {
           100,
           wallet_1.address,
           client.getContractAddress(),
-          "citycoins"
+          TOKEN_NAME
         );
 
       });
@@ -1146,7 +1148,7 @@ describe('[CityCoin]', () => {
           stackedAmount,
           client.getContractAddress(),
           stacker.address,
-          'citycoins'
+          TOKEN_NAME
         );
       })
     });


### PR DESCRIPTION
This PR fixes tests and contract after incomplete token rename.

BTW. I think function `get-name` should return exact token name which is `miamicoin` not `MiamiCoin`.
@whoabuddy what do you think?