### PR TITLE
Revert fungible token name change

### DIFF
--- a/contracts/citycoin.clar
+++ b/contracts/citycoin.clar
@@ -226,7 +226,7 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
 )
 
 ;; The fungible token that can be Stacked.
-(define-fungible-token miamicoin)
+(define-fungible-token citycoins)
 
 (define-public (register-miner (memo (optional (buff 34))))
     (let
@@ -357,7 +357,7 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
             (ok
                 (let (
                     (token-info (get-tokens-per-cycle cur-reward-cycle))
-                    (total-ft-supply (ft-get-supply miamicoin))
+                    (total-ft-supply (ft-get-supply citycoins))
                     (total-ustx-supply (stx-get-balance (as-contract tx-sender)))
                 )
                 {
@@ -377,7 +377,7 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
 
 ;; Produce the new tokens for the given claimant, who won the tokens at the given Stacks block height.
 (define-private (mint-coinbase (recipient principal) (stacks-block-ht uint))
-    (ft-mint? miamicoin (get-coinbase-amount stacks-block-ht) recipient)
+    (ft-mint? citycoins (get-coinbase-amount stacks-block-ht) recipient)
 )
 
 ;; Getter to obtain the list of miners and uSTX commitments at a given Stacks block height,
@@ -802,7 +802,7 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
     (begin
         (try! (can-stack-tokens tx-sender amount-tokens block-height start-stacks-ht lock-period))
 
-        (unwrap! (ft-transfer? miamicoin amount-tokens tx-sender (as-contract tx-sender))
+        (unwrap! (ft-transfer? citycoins amount-tokens tx-sender (as-contract tx-sender))
             (err ERR-INSUFFICIENT-BALANCE))
 
         (fold stack-tokens-closure REWARD-CYCLE-INDEXES
@@ -979,24 +979,24 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
         (asserts! (is-eq from tx-sender)
             (err ERR-UNAUTHORIZED))
 
-        (ft-transfer? miamicoin amount from to)
+        (ft-transfer? citycoins amount from to)
     )
 )
 
 (define-read-only (get-name)
-    (ok "MiamiCoin"))
+    (ok "citycoins"))
 
 (define-read-only (get-symbol)
-    (ok "MIA"))
+    (ok "CYCN"))
 
 (define-read-only (get-decimals)
     (ok u0))
 
 (define-read-only (get-balance (user principal))
-    (ok (ft-get-balance miamicoin user)))
+    (ok (ft-get-balance citycoins user)))
 
 (define-read-only (get-total-supply)
-    (ok (ft-get-supply miamicoin)))
+    (ok (ft-get-supply citycoins)))
 
 (define-read-only (get-token-uri)
     (ok (var-get token-uri)))


### PR DESCRIPTION
In commit 14ebfce the token name was changed prematurely and broke tests. This PR reverts the status through an additional commit versus a `git revert` based on recommendations in the [git documentation](https://git-scm.com/docs/git-revert.html) and [linked how-to](https://github.com/git/git/blob/master/Documentation/howto/revert-a-faulty-merge.txt).