### PR TITLE
Add lifecycle trait + initial implementation

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -5,6 +5,10 @@ name = "citycoin"
 path = "contracts/clarinet/sip-10-ft-standard.clar"
 depends_on = []
 
+[contracts.citycoin-lifecycle-trait]
+path = "contracts/clarinet/citycoin-lifecycle-trait.clar"
+depends_on = []
+
 [contracts.token]
 path = "contracts/clarinet/token.clar"
 depends_on = ["sip-010-trait"]
@@ -15,7 +19,7 @@ depends_on = []
 
 [contracts.citycoin]
 path = "contracts/clarinet/citycoin.clar"
-depends_on = ["token", "bitcoin-vrf"]
+depends_on = ["citycoin-lifecycle-trait", "token", "bitcoin-vrf"]
 
 # contracts listed below are used only in test suite
 [contracts.test-utils]

--- a/contracts/citycoin-lifecycle-trait.clar
+++ b/contracts/citycoin-lifecycle-trait.clar
@@ -1,0 +1,30 @@
+(define-trait lifecycle-trait (
+    ;; Triggers startup procedure
+    ;; - immediately, at current block height
+    ;; - optional: at passed block height (has to be in future)
+    (startup ((optional uint))
+      (response bool uint)
+    )
+    
+    ;; Triggers shutdown procedure
+    ;; - immediately, at current block height
+    ;; - optional: at passed block height (has to be in future)
+    (shutdown ((optional uint))
+      (response bool uint)
+    )
+
+    ;; Returns information about
+    ;;  - contract version
+    ;;  - when it has been or will be started 
+    ;;  - when it has been or will be shutdown
+    ;;  - current state
+    (get-contract-info () (response 
+        {
+            version: (string-ascii 12),
+            startupBH: (optional uint),
+            shutdownBH: (optional uint),
+            state: uint
+        }
+        uint    
+    ))
+))

--- a/contracts/citycoin.clar
+++ b/contracts/citycoin.clar
@@ -936,3 +936,32 @@ u113 u114 u115 u116 u117 u118 u119 u120 u121 u122 u123 u124 u125 u126 u127 u128
     (ok (var-set city-wallet wallet-address))
   )
 )
+
+;;
+;; LIFECYCLE TRAIT FUNCTIONS
+;;
+(impl-trait .citycoin-lifecycle-trait.lifecycle-trait)
+
+(define-constant CONTRACT_VERSION "0.0.1")
+(define-data-var startupBH (optional uint) none)
+(define-data-var shutdownBH (optional uint) none)
+(define-data-var state uint u0)
+
+(define-read-only (get-contract-info)
+    (ok {
+        version: CONTRACT_VERSION,
+        startupBH: (var-get startupBH),
+        shutdownBH: (var-get shutdownBH),
+        state: (var-get state)
+    })
+)
+
+(define-public (startup (height (optional uint)))
+    ;; not implemented
+    (ok (var-set startupBH height))
+)
+
+(define-public (shutdown (height (optional uint)))
+    ;; not implemented
+    (ok (var-set shutdownBH height))
+)


### PR DESCRIPTION
This PR introduces lifecycle trait contract, that defines 3 functions that other contracts we want to be upgradable and/or have functionality that allows to startup or shutdown them immediately or in the future.

Implementation in `citycoin` contract doesn't have any tests, as main logic for `startup` and `shutdown` functions will be created in separate PR.

Close #112 