### PR TITLE
Testing new codecov uploader v2

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,7 +4,7 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: "70...90"
 
 parsers:
   gcov:

--- a/.github/workflows/test-contract.yaml
+++ b/.github/workflows/test-contract.yaml
@@ -3,7 +3,7 @@
 
 # Uses a prepare script outlined in testing section of README
 
-name: Test Contract
+name: Contract Tests
 
 # Controls when the action will run.
 on:
@@ -33,7 +33,6 @@ jobs:
         with:
           args: test --coverage
       - name: "Upload code coverage"
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           files: ./coverage.lcov
-          verbose: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CityCoins on Stacks
 
-[![Contract Tests](https://github.com/citycoins/citycoin/actions/workflows/test-contract.yaml/badge.svg)](https://github.com/citycoins/citycoin/actions/workflows/test-contract.yaml) [![codecov.io](https://codecov.io/github/citycoins/citycoin/coverage.svg?branch=master)](https://codecov.io/github/citycoins/citycoin?branch=master) [![Discord Chat](https://img.shields.io/discord/856920147381190717?label=Discord)](https://discord.com/invite/tANUVBz9bk)
+[![Contract Tests](https://github.com/citycoins/citycoin/actions/workflows/test-contract.yaml/badge.svg)](https://github.com/citycoins/citycoin/actions/workflows/test-contract.yaml) [![codecov.io](https://codecov.io/github/citycoins/citycoin/coverage.svg?branch=master)](https://codecov.io/github/citycoins/citycoin?branch=main) [![Discord Chat](https://img.shields.io/discord/856920147381190717?label=Discord)](https://discord.com/invite/tANUVBz9bk)
 
 ## Abstract
 

--- a/contracts/citycoin-core-v1.clar
+++ b/contracts/citycoin-core-v1.clar
@@ -789,3 +789,8 @@
 (define-private (is-authorized-owner)
   (is-eq contract-caller CONTRACT_OWNER)
 )
+
+;; check if contract caller is auth contract
+(define-private (is-authorized-auth)
+  (is-eq contract-caller .citycoin-auth)
+)

--- a/contracts/citycoin-core-v1.clar
+++ b/contracts/citycoin-core-v1.clar
@@ -789,8 +789,3 @@
 (define-private (is-authorized-owner)
   (is-eq contract-caller CONTRACT_OWNER)
 )
-
-;; check if contract caller is auth contract
-(define-private (is-authorized-auth)
-  (is-eq contract-caller .citycoin-auth)
-)


### PR DESCRIPTION
Given the fact this still wasn't working, I found some documentation that referenced the bash uploader and v1 action being phased out in favor of this one. Opening this PR to test - still a WIP! :construction: 

Also reduces the top threshold from 100 to 90% coverage for all green.

And updates "Test Contract" to "Contract Tests", looks better in the readme badge.