### PR TITLE
Add mining over multiple blocks

### DIFF
--- a/contracts/citycoin-core-v1.clar
+++ b/contracts/citycoin-core-v1.clar
@@ -298,8 +298,8 @@
   )
 )
 
-(define-public (mine-many (data (list 200 {shift: uint, ustx: uint})))
-  (match (fold mine-single data (ok { userId: (get-or-create-user-id tx-sender), toStackers: u0, toCity: u0 }))
+(define-public (mine-many (amounts (list 200 uint)))
+  (match (fold mine-single amounts (ok { userId: (get-or-create-user-id tx-sender), toStackers: u0, toCity: u0, stacksHeight: block-height }))
     okReturn 
     (begin
       (asserts! (>= (stx-get-balance tx-sender) (+ (get toStackers okReturn) (get toCity okReturn))) (err ERR_INSUFFICIENT_BALANCE))
@@ -315,12 +315,13 @@
 )
 
 (define-private (mine-single 
-  (data { shift: uint, ustx: uint }) 
+  (amountUstx uint) 
   (return (response 
     { 
       userId: uint,
       toStackers: uint,
-      toCity: uint
+      toCity: uint,
+      stacksHeight: uint
     }
     uint
   )))
@@ -328,8 +329,7 @@
   (match return okReturn
     (let
       (
-        (stacksHeight (+ block-height (get shift data)))
-        (amountUstx (get ustx data))
+        (stacksHeight (get stacksHeight okReturn))
         (rewardCycle (default-to u0 (get-reward-cycle stacksHeight)))
         (stackingActive (stacking-active-at-cycle rewardCycle))
         (toCity
@@ -346,7 +346,8 @@
       (ok (merge okReturn 
         {
           toStackers: (+ (get toStackers okReturn) toStackers),
-          toCity: (+ (get toCity okReturn) toCity)
+          toCity: (+ (get toCity okReturn) toCity),
+          stacksHeight: (+ stacksHeight u1)
         }
       ))
     )

--- a/contracts/citycoin-core-v1.clar
+++ b/contracts/citycoin-core-v1.clar
@@ -299,18 +299,21 @@
 )
 
 (define-public (mine-many (amounts (list 200 uint)))
-  (match (fold mine-single amounts (ok { userId: (get-or-create-user-id tx-sender), toStackers: u0, toCity: u0, stacksHeight: block-height }))
-    okReturn 
-    (begin
-      (asserts! (>= (stx-get-balance tx-sender) (+ (get toStackers okReturn) (get toCity okReturn))) (err ERR_INSUFFICIENT_BALANCE))
-      (if (> (get toStackers okReturn ) u0)
-        (try! (stx-transfer? (get toStackers okReturn ) tx-sender (as-contract tx-sender)))
-        false
+  (begin
+    (asserts! (> (len amounts) u0) (err ERR_INSUFFICIENT_COMMITMENT))
+    (match (fold mine-single amounts (ok { userId: (get-or-create-user-id tx-sender), toStackers: u0, toCity: u0, stacksHeight: block-height }))
+      okReturn 
+      (begin
+        (asserts! (>= (stx-get-balance tx-sender) (+ (get toStackers okReturn) (get toCity okReturn))) (err ERR_INSUFFICIENT_BALANCE))
+        (if (> (get toStackers okReturn ) u0)
+          (try! (stx-transfer? (get toStackers okReturn ) tx-sender (as-contract tx-sender)))
+          false
+        )
+        (try! (stx-transfer? (get toCity okReturn) tx-sender (var-get cityWallet)))
+        (ok true)
       )
-      (try! (stx-transfer? (get toCity okReturn) tx-sender (var-get cityWallet)))
-      (ok true)
+      errReturn (err errReturn)
     )
-    errReturn (err errReturn)
   )
 )
 

--- a/contracts/clarinet/citycoin-core-v1.clar
+++ b/contracts/clarinet/citycoin-core-v1.clar
@@ -298,8 +298,8 @@
   )
 )
 
-(define-public (mine-many (data (list 200 {shift: uint, ustx: uint})))
-  (match (fold mine-single data (ok { userId: (get-or-create-user-id tx-sender), toStackers: u0, toCity: u0 }))
+(define-public (mine-many (amounts (list 200 uint)))
+  (match (fold mine-single amounts (ok { userId: (get-or-create-user-id tx-sender), toStackers: u0, toCity: u0, stacksHeight: block-height }))
     okReturn 
     (begin
       (asserts! (>= (stx-get-balance tx-sender) (+ (get toStackers okReturn) (get toCity okReturn))) (err ERR_INSUFFICIENT_BALANCE))
@@ -315,12 +315,13 @@
 )
 
 (define-private (mine-single 
-  (data { shift: uint, ustx: uint }) 
+  (amountUstx uint) 
   (return (response 
     { 
       userId: uint,
       toStackers: uint,
-      toCity: uint
+      toCity: uint,
+      stacksHeight: uint
     }
     uint
   )))
@@ -328,8 +329,7 @@
   (match return okReturn
     (let
       (
-        (stacksHeight (+ block-height (get shift data)))
-        (amountUstx (get ustx data))
+        (stacksHeight (get stacksHeight okReturn))
         (rewardCycle (default-to u0 (get-reward-cycle stacksHeight)))
         (stackingActive (stacking-active-at-cycle rewardCycle))
         (toCity
@@ -346,7 +346,8 @@
       (ok (merge okReturn 
         {
           toStackers: (+ (get toStackers okReturn) toStackers),
-          toCity: (+ (get toCity okReturn) toCity)
+          toCity: (+ (get toCity okReturn) toCity),
+          stacksHeight: (+ stacksHeight u1)
         }
       ))
     )

--- a/contracts/clarinet/citycoin-core-v1.clar
+++ b/contracts/clarinet/citycoin-core-v1.clar
@@ -304,7 +304,6 @@
     (match (fold mine-single amounts (ok { userId: (get-or-create-user-id tx-sender), toStackers: u0, toCity: u0, stacksHeight: block-height }))
       okReturn 
       (begin
-        (asserts! (> (+ (get toStackers okReturn) (get toCity okReturn)) u0) (err ERR_INSUFFICIENT_COMMITMENT))
         (asserts! (>= (stx-get-balance tx-sender) (+ (get toStackers okReturn) (get toCity okReturn))) (err ERR_INSUFFICIENT_BALANCE))
         (if (> (get toStackers okReturn ) u0)
           (try! (stx-transfer? (get toStackers okReturn ) tx-sender (as-contract tx-sender)))

--- a/src/core-client.ts
+++ b/src/core-client.ts
@@ -130,6 +130,13 @@ export class CoreClient extends Client {
     );
   }
 
+  hasMinedAtBlock(stacksHeight: number, userId: number): ReadOnlyFn {
+    return this.callReadOnlyFn("has-mined-at-block", [
+      types.uint(stacksHeight),
+      types.uint(userId),
+    ]);
+  }
+
   //////////////////////////////////////////////////
   // MINING REWARD CLAIM ACTIONS
   //////////////////////////////////////////////////

--- a/src/core-client.ts
+++ b/src/core-client.ts
@@ -121,6 +121,15 @@ export class CoreClient extends Client {
     );
   }
 
+  mineMany(amounts: number[], miner: Account): Tx {
+    return Tx.contractCall(
+      this.contractName,
+      "mine-many",
+      [types.list(amounts.map((amount) => types.uint(amount)))],
+      miner.address
+    );
+  }
+
   //////////////////////////////////////////////////
   // MINING REWARD CLAIM ACTIONS
   //////////////////////////////////////////////////

--- a/tests/citycoin-core-v1.test.ts
+++ b/tests/citycoin-core-v1.test.ts
@@ -388,6 +388,191 @@ describe("[CityCoin Core]", () => {
           .expectUint(CoreClient.ErrCode.ERR_USER_ALREADY_MINED);
       });
     });
+
+    describe("mine-many()", () => {
+      it("throws ERR_STACKING_NOT_AVAILABLE", (chain, accounts, clients) => {
+        // arrange
+        const miner = accounts.get("wallet_1")!;
+        const amounts = [1, 2, 3, 4];
+        // act
+        const receipt = chain.mineBlock([clients.core.mineMany(amounts, miner)])
+          .receipts[0];
+
+        // assert
+        receipt.result
+          .expectErr()
+          .expectUint(CoreClient.ErrCode.ERR_STACKING_NOT_AVAILABLE);
+      });
+
+      it("throws ERR_INSUFFICIENT_COMMITMENT while providing empty list of amounts", (chain, accounts, clients) => {
+        // arrange
+        const miner = accounts.get("wallet_1")!;
+        const amounts: number[] = [];
+        const setupBlock = chain.mineBlock([
+          clients.core.unsafeSetActivationThreshold(1),
+          clients.core.registerUser(miner),
+        ]);
+        chain.mineEmptyBlockUntil(
+          setupBlock.height + CoreClient.ACTIVATION_DELAY - 1
+        );
+
+        // act
+        const receipt = chain.mineBlock([clients.core.mineMany(amounts, miner)])
+          .receipts[0];
+
+        // assert
+        receipt.result
+          .expectErr()
+          .expectUint(CoreClient.ErrCode.ERR_INSUFFICIENT_COMMITMENT);
+      });
+
+      it("throws ERR_INSUFFICIENT_COMMITMENT while providing list of amounts filled with 0", (chain, accounts, clients) => {
+        // arrange
+        const miner = accounts.get("wallet_1")!;
+        const amounts = [0, 0, 0, 0];
+        const setupBlock = chain.mineBlock([
+          clients.core.unsafeSetActivationThreshold(1),
+          clients.core.registerUser(miner),
+        ]);
+        chain.mineEmptyBlockUntil(
+          setupBlock.height + CoreClient.ACTIVATION_DELAY - 1
+        );
+
+        // act
+        const receipt = chain.mineBlock([clients.core.mineMany(amounts, miner)])
+          .receipts[0];
+
+        // assert
+        receipt.result
+          .expectErr()
+          .expectUint(CoreClient.ErrCode.ERR_INSUFFICIENT_COMMITMENT);
+      });
+
+      it("throws ERR_INSUFFICIENT_COMMITMENT while providing list of amounts with one or more 0s", (chain, accounts, clients) => {
+        // arrange
+        const miner = accounts.get("wallet_1")!;
+        const amounts = [1, 2, 3, 4, 0, 5, 6, 7];
+        const setupBlock = chain.mineBlock([
+          clients.core.unsafeSetActivationThreshold(1),
+          clients.core.registerUser(miner),
+        ]);
+        chain.mineEmptyBlockUntil(
+          setupBlock.height + CoreClient.ACTIVATION_DELAY - 1
+        );
+
+        // act
+        const receipt = chain.mineBlock([clients.core.mineMany(amounts, miner)])
+          .receipts[0];
+
+        // assert
+        receipt.result
+          .expectErr()
+          .expectUint(CoreClient.ErrCode.ERR_INSUFFICIENT_COMMITMENT);
+      });
+
+      it("throws ERR_INSUFFICIENT_BALANCE when sum of all commitments > miner balance", (chain, accounts, clients) => {
+        // arrange
+        const miner = accounts.get("wallet_1")!;
+        const amounts = [1, miner.balance];
+        const setupBlock = chain.mineBlock([
+          clients.core.unsafeSetActivationThreshold(1),
+          clients.core.registerUser(miner),
+        ]);
+        chain.mineEmptyBlockUntil(
+          setupBlock.height + CoreClient.ACTIVATION_DELAY - 1
+        );
+
+        // act
+        const receipt = chain.mineBlock([clients.core.mineMany(amounts, miner)])
+          .receipts[0];
+
+        // assert
+        receipt.result
+          .expectErr()
+          .expectUint(CoreClient.ErrCode.ERR_INSUFFICIENT_BALANCE);
+      });
+
+      it("throws ERR_USER_ALREADY_MINED when call overlaps already mined blocks", (chain, accounts, clients) => {
+        // arrange
+        const miner = accounts.get("wallet_1")!;
+        const amounts = [1, 2];
+        const setupBlock = chain.mineBlock([
+          clients.core.unsafeSetActivationThreshold(1),
+          clients.core.registerUser(miner),
+        ]);
+        chain.mineEmptyBlockUntil(
+          setupBlock.height + CoreClient.ACTIVATION_DELAY - 1
+        );
+        chain.mineBlock([clients.core.mineMany(amounts, miner)]);
+
+        // act
+        const receipt = chain.mineBlock([clients.core.mineMany(amounts, miner)])
+          .receipts[0];
+
+        // assert
+        receipt.result
+          .expectErr()
+          .expectUint(CoreClient.ErrCode.ERR_USER_ALREADY_MINED);
+      });
+
+      it("succeeds and cause one STX transfer event when amounts list have only one value and there are no stackers", (chain, accounts, clients) => {
+        // arrange
+        const miner = accounts.get("wallet_1")!;
+        const amounts = [1];
+        const cityWallet = accounts.get("city_wallet")!;
+        const setupBlock = chain.mineBlock([
+          clients.core.unsafeSetActivationThreshold(1),
+          clients.core.registerUser(miner),
+        ]);
+        chain.mineEmptyBlockUntil(
+          setupBlock.height + CoreClient.ACTIVATION_DELAY - 1
+        );
+
+        // act
+        const receipt = chain.mineBlock([clients.core.mineMany(amounts, miner)])
+          .receipts[0];
+
+        // assert
+        receipt.result.expectOk().expectBool(true);
+
+        assertEquals(receipt.events.length, 1);
+
+        receipt.events.expectSTXTransferEvent(
+          amounts.reduce((sum, amount) => sum + amount, 0),
+          miner.address,
+          cityWallet.address
+        );
+      });
+
+      it("succeeds and cause one STX transfer event when amounts list have multiple values and there are no stackers", (chain, accounts, clients) => {
+        // arrange
+        const miner = accounts.get("wallet_1")!;
+        const amounts = [1, 2, 200, 89, 3423];
+        const cityWallet = accounts.get("city_wallet")!;
+        const setupBlock = chain.mineBlock([
+          clients.core.unsafeSetActivationThreshold(1),
+          clients.core.registerUser(miner),
+        ]);
+        chain.mineEmptyBlockUntil(
+          setupBlock.height + CoreClient.ACTIVATION_DELAY - 1
+        );
+
+        // act
+        const receipt = chain.mineBlock([clients.core.mineMany(amounts, miner)])
+          .receipts[0];
+
+        // assert
+        receipt.result.expectOk().expectBool(true);
+
+        assertEquals(receipt.events.length, 1);
+
+        receipt.events.expectSTXTransferEvent(
+          amounts.reduce((sum, amount) => sum + amount, 0),
+          miner.address,
+          cityWallet.address
+        );
+      });
+    });
   });
 
   //////////////////////////////////////////////////

--- a/tests/citycoin-core-v1.test.ts
+++ b/tests/citycoin-core-v1.test.ts
@@ -664,6 +664,31 @@ describe("[CityCoin Core]", () => {
           clients.core.getContractAddress()
         );
       });
+
+      it("saves information that miner mined multiple consecutive blocks", (chain, accounts, clients) => {
+        // arrange
+        const miner = accounts.get("wallet_1")!;
+        const amounts = [1, 2, 200, 89, 3423];
+        const setupBlock = chain.mineBlock([
+          clients.core.unsafeSetActivationThreshold(1),
+          clients.core.registerUser(miner),
+        ]);
+        chain.mineEmptyBlockUntil(
+          setupBlock.height + CoreClient.ACTIVATION_DELAY - 1
+        );
+
+        // act
+        const block = chain.mineBlock([clients.core.mineMany(amounts, miner)]);
+
+        // assert
+        const userId = 1;
+
+        amounts.forEach((amount, idx) => {
+          clients.core
+            .hasMinedAtBlock(block.height + idx - 1, userId)
+            .result.expectBool(true);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Add mining over multiple blocks.

Miners can mine up to 200 blocks at a time, and pick different amount fore each one of them. 
Mining 200 blocks might fail due to executions costs being to high, but Stacks 2.1 should (in theory) solve that.

close #129