### PR TITLE
Add is-block-winner function

### DIFF
--- a/contracts/citycoin-core-v1.clar
+++ b/contracts/citycoin-core-v1.clar
@@ -512,6 +512,24 @@
   )
 )
 
+(define-read-only (is-block-winner (user principal) (minerBlockHeight uint))
+  (let
+    (
+      (userId (unwrap! (get-user-id user) false))
+      (blockStats (unwrap! (get-mining-stats-at-block minerBlockHeight) false))
+      (minerStats (unwrap! (get-miner-at-block minerBlockHeight userId) false))
+      (maturityHeight (+ (var-get tokenRewardMaturity) minerBlockHeight))
+      (vrfSample (unwrap! (contract-call? .citycoin-vrf get-random-uint-at-block maturityHeight) false))
+      (commitTotal (get-last-high-value-at-block minerBlockHeight))
+      (winningValue (mod vrfSample commitTotal))
+    )
+    (if (and (>= winningValue (get lowValue minerStats)) (<= winningValue (get highValue minerStats)))
+      true
+      false
+    )
+  )
+)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; STACKING CONFIGURATION
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/contracts/clarinet/citycoin-core-v1.clar
+++ b/contracts/clarinet/citycoin-core-v1.clar
@@ -512,6 +512,24 @@
   )
 )
 
+(define-read-only (is-block-winner (user principal) (minerBlockHeight uint))
+  (let
+    (
+      (userId (unwrap! (get-user-id user) false))
+      (blockStats (unwrap! (get-mining-stats-at-block minerBlockHeight) false))
+      (minerStats (unwrap! (get-miner-at-block minerBlockHeight userId) false))
+      (maturityHeight (+ (var-get tokenRewardMaturity) minerBlockHeight))
+      (vrfSample (unwrap! (contract-call? .citycoin-vrf get-random-uint-at-block maturityHeight) false))
+      (commitTotal (get-last-high-value-at-block minerBlockHeight))
+      (winningValue (mod vrfSample commitTotal))
+    )
+    (if (and (>= winningValue (get lowValue minerStats)) (<= winningValue (get highValue minerStats)))
+      true
+      false
+    )
+  )
+)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; STACKING CONFIGURATION
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/core-client.ts
+++ b/src/core-client.ts
@@ -157,6 +157,13 @@ export class CoreClient extends Client {
     );
   }
 
+  isBlockWinner(user: Account, minerBlockHeight: number): ReadOnlyFn {
+    return this.callReadOnlyFn("is-block-winner", [
+      types.principal(user.address),
+      types.uint(minerBlockHeight),
+    ]);
+  }
+
   //////////////////////////////////////////////////
   // STACKING CONFIGURATION
   //////////////////////////////////////////////////


### PR DESCRIPTION
This PR introduces read-only function `is-block-winner` that returns `true` if user is a block winner, and `false` when he is not.
It doesn't check if user can claim the reward - just tells if user is a block winner or not.