### PR TITLE
Chore: Remove CityCoin phrase from contracts

### DIFF
--- a/contracts/citycoin-auth.clar
+++ b/contracts/citycoin-auth.clar
@@ -287,7 +287,7 @@
 
 ;; initial value for active core contract
 ;; set to deployer address at startup to prevent
-;; circular dependency of citycoin-core on citycoin-auth
+;; circular dependency of core on auth
 (define-data-var activeCoreContract principal CONTRACT_OWNER)
 (define-data-var initialized bool false)
 

--- a/contracts/citycoin-auth.clar
+++ b/contracts/citycoin-auth.clar
@@ -297,7 +297,7 @@
 (define-constant STATE_INACTIVE u2)
 
 ;; core contract map
-(define-map CityCoinCoreContracts
+(define-map CoreContracts
   principal
   {
     state: uint, 
@@ -318,7 +318,7 @@
 (define-read-only (get-core-contract-info (targetContract principal))
   (let
     (
-      (coreContract (unwrap! (map-get? CityCoinCoreContracts targetContract) (err ERR_CORE_CONTRACT_NOT_FOUND)))
+      (coreContract (unwrap! (map-get? CoreContracts targetContract) (err ERR_CORE_CONTRACT_NOT_FOUND)))
     )
     (ok coreContract)
   )
@@ -337,7 +337,7 @@
     )
     (asserts! (is-eq contract-caller CONTRACT_OWNER) (err ERR_UNAUTHORIZED))
     (asserts! (not (var-get initialized)) (err ERR_UNAUTHORIZED))
-    (map-set CityCoinCoreContracts
+    (map-set CoreContracts
       coreContractAddress
       {
         state: STATE_DEPLOYED,
@@ -358,10 +358,10 @@
 (define-public (activate-core-contract (targetContract principal) (stacksHeight uint))
   (let
     (
-      (coreContract (unwrap! (map-get? CityCoinCoreContracts targetContract) (err ERR_CORE_CONTRACT_NOT_FOUND)))
+      (coreContract (unwrap! (map-get? CoreContracts targetContract) (err ERR_CORE_CONTRACT_NOT_FOUND)))
     )
     (asserts! (is-eq contract-caller targetContract) (err ERR_UNAUTHORIZED))
-    (map-set CityCoinCoreContracts
+    (map-set CoreContracts
       targetContract
       {
         state: STATE_ACTIVE,
@@ -377,20 +377,20 @@
   (let
     (
       (oldContractAddress (contract-of oldContract))
-      (oldContractMap (unwrap! (map-get? CityCoinCoreContracts oldContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
+      (oldContractMap (unwrap! (map-get? CoreContracts oldContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
       (newContractAddress (contract-of newContract))
     )
     (asserts! (not (is-eq oldContractAddress newContractAddress)) (err ERR_UNAUTHORIZED))
     (asserts! (is-authorized-city) (err ERR_UNAUTHORIZED))
     ;; TODO: allow call via approved job
-    (map-set CityCoinCoreContracts
+    (map-set CoreContracts
       oldContractAddress
       {
         state: STATE_INACTIVE,
         startHeight: (get startHeight oldContractMap),
         endHeight: block-height
       })
-    (map-set CityCoinCoreContracts
+    (map-set CoreContracts
       newContractAddress
       {
         state: STATE_DEPLOYED,
@@ -410,20 +410,20 @@
       (oldContractArg (unwrap! (get-principal-value-by-name jobId "oldContract") (err ERR_UNKNOWN_ARGUMENT)))
       (newContractArg (unwrap! (get-principal-value-by-name jobId "newContract") (err ERR_UNKNOWN_ARGUMENT)))
       (oldContractAddress (contract-of oldContract))
-      (oldContractMap (unwrap! (map-get? CityCoinCoreContracts oldContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
+      (oldContractMap (unwrap! (map-get? CoreContracts oldContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
       (newContractAddress (contract-of newContract))
     )
     (asserts! (is-approver contract-caller) (err ERR_UNAUTHORIZED))
     (asserts! (and (is-eq oldContractArg oldContractAddress) (is-eq newContractArg newContractAddress)) (err ERR_UNAUTHORIZED))
     (asserts! (not (is-eq oldContractAddress newContractAddress)) (err ERR_UNAUTHORIZED))
-    (map-set CityCoinCoreContracts
+    (map-set CoreContracts
       oldContractAddress
       {
         state: STATE_INACTIVE,
         startHeight: (get startHeight oldContractMap),
         endHeight: block-height
       })
-    (map-set CityCoinCoreContracts
+    (map-set CoreContracts
       newContractAddress
       {
         state: STATE_DEPLOYED,
@@ -454,7 +454,7 @@
   (let
     (
       (coreContractAddress (contract-of targetContract))
-      (coreContract (unwrap! (map-get? CityCoinCoreContracts coreContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
+      (coreContract (unwrap! (map-get? CoreContracts coreContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
     )
     (asserts! (is-authorized-city) (err ERR_UNAUTHORIZED))
     ;; TODO: allow call via approved job
@@ -469,7 +469,7 @@
   (let
     (
       (coreContractAddress (contract-of targetContract))
-      (coreContract (unwrap! (map-get? CityCoinCoreContracts coreContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
+      (coreContract (unwrap! (map-get? CoreContracts coreContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
       (newCityWallet (unwrap! (get-principal-value-by-name jobId "newCityWallet") (err ERR_UNKNOWN_ARGUMENT)))
     )
     (asserts! (is-approver contract-caller) (err ERR_UNAUTHORIZED))

--- a/contracts/citycoin-core-v1.clar
+++ b/contracts/citycoin-core-v1.clar
@@ -1,6 +1,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; CITYCOIN CORE CONTRACT
+;; CORE CONTRACT
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -854,7 +854,7 @@
     (asserts! (>= minerBlockHeight (var-get activationBlock)) u0)
     ;; if contract is active, return based on issuance schedule
     ;; halvings occur every 210,000 blocks for 1,050,000 Stacks blocks
-    ;; then mining continues indefinitely with 3,125 CityCoins as the reward
+    ;; then mining continues indefinitely with 3,125 tokens as the reward
     (asserts! (> minerBlockHeight (var-get coinbaseThreshold1))
       (if (<= (- minerBlockHeight (var-get activationBlock)) u10000)
         ;; bonus reward first 10,000 blocks
@@ -910,7 +910,7 @@
   (is-eq contract-caller CONTRACT_OWNER)
 )
 
-;; checks if caller is CityCoin Auth contract
+;; checks if caller is Auth contract
 (define-private (is-authorized-auth)
   (is-eq contract-caller .citycoin-auth)
 )

--- a/contracts/citycoin-core-v2.clar
+++ b/contracts/citycoin-core-v2.clar
@@ -1,6 +1,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; CITYCOIN CORE CONTRACT
+;; CORE CONTRACT
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -772,7 +772,7 @@
     (asserts! (>= minerBlockHeight (var-get activationBlock)) u0)
     ;; if contract is active, return based on issuance schedule
     ;; halvings occur every 210,000 blocks for 1,050,000 Stacks blocks
-    ;; then mining continues indefinitely with 3,125 CityCoins as the reward
+    ;; then mining continues indefinitely with 3,125 tokens as the reward
     (asserts! (> minerBlockHeight (var-get coinbaseThreshold1))
       (if (<= (- minerBlockHeight (var-get activationBlock)) u10000)
         ;; bonus reward first 10,000 blocks
@@ -828,7 +828,7 @@
   (is-eq contract-caller CONTRACT_OWNER)
 )
 
-;; checks if caller is CityCoin Auth contract
+;; checks if caller is Auth contract
 (define-private (is-authorized-auth)
   (is-eq contract-caller .citycoin-auth)
 )

--- a/contracts/citycoin-token.clar
+++ b/contracts/citycoin-token.clar
@@ -1,6 +1,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; CITYCOIN TOKEN CONTRACT
+;; TOKEN CONTRACT
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -14,7 +14,7 @@
 ;; TRAIT DEFINITIONS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; (impl-trait .citycoin-token-trait.citycoin-token)
+(impl-trait .citycoin-token-trait.citycoin-token)
 (use-trait coreTrait .citycoin-core-trait.citycoin-core)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -132,7 +132,7 @@
 
 (define-data-var tokenUri (optional (string-utf8 256)) (some u"https://cdn.citycoins.co/metadata/citycoin.json"))
 
-;; set token URI to new value, only accessible by CityCoin Auth
+;; set token URI to new value, only accessible by Auth
 (define-public (set-token-uri (newUri (optional (string-utf8 256))))
   (begin
     (asserts! (is-authorized-auth) (err ERR_UNAUTHORIZED))
@@ -140,7 +140,7 @@
   )
 )
 
-;; mint new tokens, only accessible by a CityCoin Core contract
+;; mint new tokens, only accessible by a Core contract
 (define-public (mint (amount uint) (recipient principal))
   (let
     (
@@ -150,7 +150,7 @@
   )
 )
 
-;; burn tokens, only accessible by a CityCoin Core contract
+;; burn tokens, only accessible by a Core contract
 (define-public (burn (amount uint) (recipient principal))
   (let
     (
@@ -160,7 +160,7 @@
   )
 )
 
-;; checks if caller is CityCoin Auth contract
+;; checks if caller is Auth contract
 (define-private (is-authorized-auth)
   (is-eq contract-caller .citycoin-auth)
 )

--- a/contracts/citycoin-token.clar
+++ b/contracts/citycoin-token.clar
@@ -171,7 +171,7 @@
 
 (define-public (send-many (recipients (list 200 { to: principal, amount: uint, memo: (optional (buff 34)) })))
   (fold check-err
-    (map send-citycoin recipients)
+    (map send-token recipients)
     (ok true)
   )
 )
@@ -182,11 +182,11 @@
   )
 )
 
-(define-private (send-citycoin (recipient { to: principal, amount: uint, memo: (optional (buff 34)) }))
-  (send-citycoin-with-memo (get amount recipient) (get to recipient) (get memo recipient))
+(define-private (send-token (recipient { to: principal, amount: uint, memo: (optional (buff 34)) }))
+  (send-token-with-memo (get amount recipient) (get to recipient) (get memo recipient))
 )
 
-(define-private (send-citycoin-with-memo (amount uint) (to principal) (memo (optional (buff 34))))
+(define-private (send-token-with-memo (amount uint) (to principal) (memo (optional (buff 34))))
   (let
     (
       (transferOk (try! (transfer amount tx-sender to memo)))

--- a/contracts/clarinet/citycoin-auth.clar
+++ b/contracts/clarinet/citycoin-auth.clar
@@ -287,7 +287,7 @@
 
 ;; initial value for active core contract
 ;; set to deployer address at startup to prevent
-;; circular dependency of citycoin-core on citycoin-auth
+;; circular dependency of core on auth
 (define-data-var activeCoreContract principal CONTRACT_OWNER)
 (define-data-var initialized bool false)
 

--- a/contracts/clarinet/citycoin-auth.clar
+++ b/contracts/clarinet/citycoin-auth.clar
@@ -297,7 +297,7 @@
 (define-constant STATE_INACTIVE u2)
 
 ;; core contract map
-(define-map CityCoinCoreContracts
+(define-map CoreContracts
   principal
   {
     state: uint, 
@@ -318,7 +318,7 @@
 (define-read-only (get-core-contract-info (targetContract principal))
   (let
     (
-      (coreContract (unwrap! (map-get? CityCoinCoreContracts targetContract) (err ERR_CORE_CONTRACT_NOT_FOUND)))
+      (coreContract (unwrap! (map-get? CoreContracts targetContract) (err ERR_CORE_CONTRACT_NOT_FOUND)))
     )
     (ok coreContract)
   )
@@ -337,7 +337,7 @@
     )
     (asserts! (is-eq contract-caller CONTRACT_OWNER) (err ERR_UNAUTHORIZED))
     (asserts! (not (var-get initialized)) (err ERR_UNAUTHORIZED))
-    (map-set CityCoinCoreContracts
+    (map-set CoreContracts
       coreContractAddress
       {
         state: STATE_DEPLOYED,
@@ -358,10 +358,10 @@
 (define-public (activate-core-contract (targetContract principal) (stacksHeight uint))
   (let
     (
-      (coreContract (unwrap! (map-get? CityCoinCoreContracts targetContract) (err ERR_CORE_CONTRACT_NOT_FOUND)))
+      (coreContract (unwrap! (map-get? CoreContracts targetContract) (err ERR_CORE_CONTRACT_NOT_FOUND)))
     )
     (asserts! (is-eq contract-caller targetContract) (err ERR_UNAUTHORIZED))
-    (map-set CityCoinCoreContracts
+    (map-set CoreContracts
       targetContract
       {
         state: STATE_ACTIVE,
@@ -377,20 +377,20 @@
   (let
     (
       (oldContractAddress (contract-of oldContract))
-      (oldContractMap (unwrap! (map-get? CityCoinCoreContracts oldContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
+      (oldContractMap (unwrap! (map-get? CoreContracts oldContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
       (newContractAddress (contract-of newContract))
     )
     (asserts! (not (is-eq oldContractAddress newContractAddress)) (err ERR_UNAUTHORIZED))
     (asserts! (is-authorized-city) (err ERR_UNAUTHORIZED))
     ;; TODO: allow call via approved job
-    (map-set CityCoinCoreContracts
+    (map-set CoreContracts
       oldContractAddress
       {
         state: STATE_INACTIVE,
         startHeight: (get startHeight oldContractMap),
         endHeight: block-height
       })
-    (map-set CityCoinCoreContracts
+    (map-set CoreContracts
       newContractAddress
       {
         state: STATE_DEPLOYED,
@@ -410,20 +410,20 @@
       (oldContractArg (unwrap! (get-principal-value-by-name jobId "oldContract") (err ERR_UNKNOWN_ARGUMENT)))
       (newContractArg (unwrap! (get-principal-value-by-name jobId "newContract") (err ERR_UNKNOWN_ARGUMENT)))
       (oldContractAddress (contract-of oldContract))
-      (oldContractMap (unwrap! (map-get? CityCoinCoreContracts oldContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
+      (oldContractMap (unwrap! (map-get? CoreContracts oldContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
       (newContractAddress (contract-of newContract))
     )
     (asserts! (is-approver contract-caller) (err ERR_UNAUTHORIZED))
     (asserts! (and (is-eq oldContractArg oldContractAddress) (is-eq newContractArg newContractAddress)) (err ERR_UNAUTHORIZED))
     (asserts! (not (is-eq oldContractAddress newContractAddress)) (err ERR_UNAUTHORIZED))
-    (map-set CityCoinCoreContracts
+    (map-set CoreContracts
       oldContractAddress
       {
         state: STATE_INACTIVE,
         startHeight: (get startHeight oldContractMap),
         endHeight: block-height
       })
-    (map-set CityCoinCoreContracts
+    (map-set CoreContracts
       newContractAddress
       {
         state: STATE_DEPLOYED,
@@ -454,7 +454,7 @@
   (let
     (
       (coreContractAddress (contract-of targetContract))
-      (coreContract (unwrap! (map-get? CityCoinCoreContracts coreContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
+      (coreContract (unwrap! (map-get? CoreContracts coreContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
     )
     (asserts! (is-authorized-city) (err ERR_UNAUTHORIZED))
     ;; TODO: allow call via approved job
@@ -469,7 +469,7 @@
   (let
     (
       (coreContractAddress (contract-of targetContract))
-      (coreContract (unwrap! (map-get? CityCoinCoreContracts coreContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
+      (coreContract (unwrap! (map-get? CoreContracts coreContractAddress) (err ERR_CORE_CONTRACT_NOT_FOUND)))
       (newCityWallet (unwrap! (get-principal-value-by-name jobId "newCityWallet") (err ERR_UNKNOWN_ARGUMENT)))
     )
     (asserts! (is-approver contract-caller) (err ERR_UNAUTHORIZED))
@@ -519,7 +519,7 @@
     )
     ;; (asserts! (is-eq contract-caller CONTRACT_OWNER) (err ERR_UNAUTHORIZED))
     (asserts! (not (var-get initialized)) (err ERR_UNAUTHORIZED))
-    (map-set CityCoinCoreContracts
+    (map-set CoreContracts
       coreContractAddress
       {
         state: STATE_DEPLOYED,

--- a/contracts/clarinet/citycoin-core-v1.clar
+++ b/contracts/clarinet/citycoin-core-v1.clar
@@ -1,6 +1,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; CITYCOIN CORE CONTRACT
+;; CORE CONTRACT
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -854,7 +854,7 @@
     (asserts! (>= minerBlockHeight (var-get activationBlock)) u0)
     ;; if contract is active, return based on issuance schedule
     ;; halvings occur every 210,000 blocks for 1,050,000 Stacks blocks
-    ;; then mining continues indefinitely with 3,125 CityCoins as the reward
+    ;; then mining continues indefinitely with 3,125 tokens as the reward
     (asserts! (> minerBlockHeight (var-get coinbaseThreshold1))
       (if (<= (- minerBlockHeight (var-get activationBlock)) u10000)
         ;; bonus reward first 10,000 blocks
@@ -910,7 +910,7 @@
   (is-eq contract-caller CONTRACT_OWNER)
 )
 
-;; checks if caller is CityCoin Auth contract
+;; checks if caller is Auth contract
 (define-private (is-authorized-auth)
   (is-eq contract-caller .citycoin-auth)
 )

--- a/contracts/clarinet/citycoin-core-v2.clar
+++ b/contracts/clarinet/citycoin-core-v2.clar
@@ -1,6 +1,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; CITYCOIN CORE CONTRACT
+;; CORE CONTRACT
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -772,7 +772,7 @@
     (asserts! (>= minerBlockHeight (var-get activationBlock)) u0)
     ;; if contract is active, return based on issuance schedule
     ;; halvings occur every 210,000 blocks for 1,050,000 Stacks blocks
-    ;; then mining continues indefinitely with 3,125 CityCoins as the reward
+    ;; then mining continues indefinitely with 3,125 tokens as the reward
     (asserts! (> minerBlockHeight (var-get coinbaseThreshold1))
       (if (<= (- minerBlockHeight (var-get activationBlock)) u10000)
         ;; bonus reward first 10,000 blocks
@@ -828,7 +828,7 @@
   (is-eq contract-caller CONTRACT_OWNER)
 )
 
-;; checks if caller is CityCoin Auth contract
+;; checks if caller is Auth contract
 (define-private (is-authorized-auth)
   (is-eq contract-caller .citycoin-auth)
 )

--- a/contracts/clarinet/citycoin-token.clar
+++ b/contracts/clarinet/citycoin-token.clar
@@ -1,6 +1,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; CITYCOIN TOKEN CONTRACT
+;; TOKEN CONTRACT
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -14,7 +14,7 @@
 ;; TRAIT DEFINITIONS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; (impl-trait .citycoin-token-trait.citycoin-token)
+(impl-trait .citycoin-token-trait.citycoin-token)
 (use-trait coreTrait .citycoin-core-trait.citycoin-core)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -132,7 +132,7 @@
 
 (define-data-var tokenUri (optional (string-utf8 256)) (some u"https://cdn.citycoins.co/metadata/citycoin.json"))
 
-;; set token URI to new value, only accessible by CityCoin Auth
+;; set token URI to new value, only accessible by Auth
 (define-public (set-token-uri (newUri (optional (string-utf8 256))))
   (begin
     (asserts! (is-authorized-auth) (err ERR_UNAUTHORIZED))
@@ -140,7 +140,7 @@
   )
 )
 
-;; mint new tokens, only accessible by a CityCoin Core contract
+;; mint new tokens, only accessible by a Core contract
 (define-public (mint (amount uint) (recipient principal))
   (let
     (
@@ -150,7 +150,7 @@
   )
 )
 
-;; burn tokens, only accessible by a CityCoin Core contract
+;; burn tokens, only accessible by a Core contract
 (define-public (burn (amount uint) (recipient principal))
   (let
     (
@@ -160,7 +160,7 @@
   )
 )
 
-;; checks if caller is CityCoin Auth contract
+;; checks if caller is Auth contract
 (define-private (is-authorized-auth)
   (is-eq contract-caller .citycoin-auth)
 )

--- a/contracts/clarinet/citycoin-token.clar
+++ b/contracts/clarinet/citycoin-token.clar
@@ -171,7 +171,7 @@
 
 (define-public (send-many (recipients (list 200 { to: principal, amount: uint, memo: (optional (buff 34)) })))
   (fold check-err
-    (map send-citycoin recipients)
+    (map send-token recipients)
     (ok true)
   )
 )
@@ -182,11 +182,11 @@
   )
 )
 
-(define-private (send-citycoin (recipient { to: principal, amount: uint, memo: (optional (buff 34)) }))
-  (send-citycoin-with-memo (get amount recipient) (get to recipient) (get memo recipient))
+(define-private (send-token (recipient { to: principal, amount: uint, memo: (optional (buff 34)) }))
+  (send-token-with-memo (get amount recipient) (get to recipient) (get memo recipient))
 )
 
-(define-private (send-citycoin-with-memo (amount uint) (to principal) (memo (optional (buff 34))))
+(define-private (send-token-with-memo (amount uint) (to principal) (memo (optional (buff 34))))
   (let
     (
       (transferOk (try! (transfer amount tx-sender to memo)))

--- a/contracts/test_addons/citycoin-auth.clar
+++ b/contracts/test_addons/citycoin-auth.clar
@@ -10,7 +10,7 @@
     )
     ;; (asserts! (is-eq contract-caller CONTRACT_OWNER) (err ERR_UNAUTHORIZED))
     (asserts! (not (var-get initialized)) (err ERR_UNAUTHORIZED))
-    (map-set CityCoinCoreContracts
+    (map-set CoreContracts
       coreContractAddress
       {
         state: STATE_DEPLOYED,


### PR DESCRIPTION
Main intent for this PR is to clean up our contract in a way that they won't have unnecessary occurrences of `CityCoin` or `CityCoins` phrase. Especially in variable, map and function names.