### PR TITLE
Add execute-replace-approver-job()

### DIFF
--- a/contracts/citycoin-auth.clar
+++ b/contracts/citycoin-auth.clar
@@ -252,7 +252,7 @@
   (default-to false (map-get? JobApprovers { jobId: jobId, approver: approver }))
 )
 
-(define-private (is-approver (user principal))
+(define-read-only (is-approver (user principal))
   (default-to false (map-get? Approvers user))
 )
 
@@ -497,6 +497,23 @@
     (ok true)
   )
 )
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; APPROVERS MANAGEMENT
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-public (execute-replace-approver-job (jobId uint))
+  (let
+    (
+      (oldApprover (unwrap! (get-principal-value-by-name jobId "oldApprover") (err ERR_UNKNOWN_ARGUMENT)))
+      (newApprover (unwrap! (get-principal-value-by-name jobId "newApprover") (err ERR_UNKNOWN_ARGUMENT)))
+    )
+    (asserts! (is-approver contract-caller) (err ERR_UNAUTHORIZED))
+    (map-set Approvers oldApprover false)
+    (map-set Approvers newApprover true)
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; CONTRACT INITIALIZATION

--- a/contracts/clarinet/citycoin-auth.clar
+++ b/contracts/clarinet/citycoin-auth.clar
@@ -252,7 +252,7 @@
   (default-to false (map-get? JobApprovers { jobId: jobId, approver: approver }))
 )
 
-(define-private (is-approver (user principal))
+(define-read-only (is-approver (user principal))
   (default-to false (map-get? Approvers user))
 )
 
@@ -497,6 +497,23 @@
     (ok true)
   )
 )
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; APPROVERS MANAGEMENT
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-public (execute-replace-approver-job (jobId uint))
+  (let
+    (
+      (oldApprover (unwrap! (get-principal-value-by-name jobId "oldApprover") (err ERR_UNKNOWN_ARGUMENT)))
+      (newApprover (unwrap! (get-principal-value-by-name jobId "newApprover") (err ERR_UNKNOWN_ARGUMENT)))
+    )
+    (asserts! (is-approver contract-caller) (err ERR_UNAUTHORIZED))
+    (map-set Approvers oldApprover false)
+    (map-set Approvers newApprover true)
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; CONTRACT INITIALIZATION

--- a/contracts/clarinet/citycoin-core-v1.clar
+++ b/contracts/clarinet/citycoin-core-v1.clar
@@ -521,7 +521,7 @@
 )
 
 (define-private (is-block-winner-and-can-claim (user principal) (minerBlockHeight uint) (testCanClaim bool))
-(let
+  (let
     (
       (userId (unwrap! (get-user-id user) false))
       (blockStats (unwrap! (get-mining-stats-at-block minerBlockHeight) false))
@@ -532,10 +532,7 @@
       (winningValue (mod vrfSample commitTotal))
     )
     (if (and (>= winningValue (get lowValue minerStats)) (<= winningValue (get highValue minerStats)))
-      (if testCanClaim
-        (not (get rewardClaimed blockStats))
-        true
-      )
+      (if testCanClaim (not (get rewardClaimed blockStats)) true)
       false
     )
   )

--- a/src/auth-client.ts
+++ b/src/auth-client.ts
@@ -51,7 +51,7 @@ export class AuthClient extends Client {
     );
   }
 
-  approveJob(jobId: number, approver: Account) {
+  approveJob(jobId: number, approver: Account): Tx {
     return Tx.contractCall(
       this.contractName,
       "approve-job",
@@ -236,6 +236,19 @@ export class AuthClient extends Client {
       this.contractName,
       "execute-set-city-wallet-job",
       [types.uint(jobId), types.principal(targetContract)],
+      sender.address
+    );
+  }
+
+  isApprover(user: Account) {
+    return this.callReadOnlyFn("is-approver", [types.principal(user.address)]);
+  }
+
+  executeReplaceApproverJob(jobId: number, sender: Account): Tx {
+    return Tx.contractCall(
+      this.contractName,
+      "execute-replace-approver-job",
+      [types.uint(jobId)],
       sender.address
     );
   }


### PR DESCRIPTION
This PR introduces function, that can be used to replace approver with new one using voting mechanism.

Job parameters:
 - `oldApprover` - old approver address (principal)
 - `newApprover` - new approver address (principal)