### PR TITLE
Add check if contract is active to mine-many

### DIFF
--- a/contracts/citycoin-core-v1.clar
+++ b/contracts/citycoin-core-v1.clar
@@ -300,6 +300,7 @@
 
 (define-public (mine-many (amounts (list 200 uint)))
   (begin
+    (asserts! (get-activation-status) (err ERR_CONTRACT_NOT_ACTIVATED))
     (asserts! (> (len amounts) u0) (err ERR_INSUFFICIENT_COMMITMENT))
     (match (fold mine-single amounts (ok { userId: (get-or-create-user-id tx-sender), toStackers: u0, toCity: u0, stacksHeight: block-height }))
       okReturn 

--- a/contracts/clarinet/citycoin-core-v1.clar
+++ b/contracts/clarinet/citycoin-core-v1.clar
@@ -300,6 +300,7 @@
 
 (define-public (mine-many (amounts (list 200 uint)))
   (begin
+    (asserts! (get-activation-status) (err ERR_CONTRACT_NOT_ACTIVATED))
     (asserts! (> (len amounts) u0) (err ERR_INSUFFICIENT_COMMITMENT))
     (match (fold mine-single amounts (ok { userId: (get-or-create-user-id tx-sender), toStackers: u0, toCity: u0, stacksHeight: block-height }))
       okReturn 


### PR DESCRIPTION
Based on this TX `mine-many` wasn't checking if contract is active the same way `mine-tokens` was:

https://explorer.stacks.co/txid/0x254fd154953266762f765f3e44e5854382d1c6ac90b04f0d5b393bb610d8daa5

This PR fixes it by adding the same guard and related tests.