### PR TITLE
Fix clarinet test error

### DIFF
--- a/settings/Devnet.toml
+++ b/settings/Devnet.toml
@@ -1,5 +1,5 @@
 [network]
-name = "Development"
+name = "Devnet"
 
 [accounts.deployer]
 # ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE


### PR DESCRIPTION
Tests are failing due to the `Devnet.toml` file not being included (based on the latest release of Clarinet), adding that now and seeing if all tests pass again.