### PR TITLE
Unlock burn function for all token owners

### DIFF
--- a/contracts/citycoin-token.clar
+++ b/contracts/citycoin-token.clar
@@ -136,13 +136,10 @@
   )
 )
 
-;; burn tokens, only accessible by a Core contract
-(define-public (burn (amount uint) (recipient principal))
-  (let
-    (
-      (coreContract (try! (contract-call? .citycoin-auth get-core-contract-info contract-caller)))
-    )
-    (ft-burn? citycoins amount recipient)
+(define-public (burn (amount uint) (owner principal))
+  (begin
+    (asserts! (is-eq tx-sender owner) (err ERR_UNAUTHORIZED))
+    (ft-burn? citycoins amount owner)
   )
 )
 

--- a/contracts/clarinet/citycoin-core-v1.clar
+++ b/contracts/clarinet/citycoin-core-v1.clar
@@ -950,10 +950,3 @@
     (ok true)
   )
 )
-
-(define-public (test-burn (amount uint) (recipient principal))
-  (begin
-    (as-contract (try! (contract-call? .citycoin-token burn amount recipient)))
-    (ok true)
-  )
-)

--- a/contracts/clarinet/citycoin-token.clar
+++ b/contracts/clarinet/citycoin-token.clar
@@ -136,13 +136,10 @@
   )
 )
 
-;; burn tokens, only accessible by a Core contract
-(define-public (burn (amount uint) (recipient principal))
-  (let
-    (
-      (coreContract (try! (contract-call? .citycoin-auth get-core-contract-info contract-caller)))
-    )
-    (ft-burn? citycoins amount recipient)
+(define-public (burn (amount uint) (owner principal))
+  (begin
+    (asserts! (is-eq tx-sender owner) (err ERR_UNAUTHORIZED))
+    (ft-burn? citycoins amount owner)
   )
 )
 

--- a/contracts/test_addons/citycoin-core-v1.clar
+++ b/contracts/test_addons/citycoin-core-v1.clar
@@ -49,10 +49,3 @@
     (ok true)
   )
 )
-
-(define-public (test-burn (amount uint) (recipient principal))
-  (begin
-    (as-contract (try! (contract-call? .citycoin-token burn amount recipient)))
-    (ok true)
-  )
-)

--- a/models/core.model.ts
+++ b/models/core.model.ts
@@ -246,12 +246,4 @@ export class CoreModel extends Model {
       sender.address
     );
   }
-
-  testBurn(amount: number, recipient: Account, sender: Account): Tx {
-    return this.callPublic(
-      "test-burn",
-      [types.uint(amount), types.principal(recipient.address)],
-      sender.address
-    );
-  }
 }

--- a/models/token.model.ts
+++ b/models/token.model.ts
@@ -43,10 +43,10 @@ export class TokenModel extends Model {
     );
   }
 
-  burn(amount: number, sender: Account): Tx {
+  burn(amount: number, owner: Account, sender: Account): Tx {
     return this.callPublic(
       "burn",
-      [types.uint(amount), types.principal(sender.address)],
+      [types.uint(amount), types.principal(owner.address)],
       sender.address
     );
   }

--- a/tests/citycoin-token.test.ts
+++ b/tests/citycoin-token.test.ts
@@ -193,33 +193,45 @@ describe("[CityCoin Token]", () => {
     });
 
     describe("burn()", () => {
-      it("throws ERR_CORE_CONTRACT_NOT_FOUND when called by someone who is not a trusted caller", () => {
+      it("throws ERR_UNAUTHORIZED when owner is different than transaction sender", () => {
         // arrange
-        const wallet = accounts.get("wallet_1")!;
+        const owner = accounts.get("wallet_1")!;
+        const sender = accounts.get("wallet_2")!;
         const amount = 500;
 
         // act
-        const receipt = chain.mineBlock([token.burn(200, wallet)])
+        const receipt = chain.mineBlock([token.burn(amount, owner, sender)])
           .receipts[0];
 
         // assert
         receipt.result
           .expectErr()
-          .expectUint(TokenModel.ErrCode.ERR_CORE_CONTRACT_NOT_FOUND);
+          .expectUint(TokenModel.ErrCode.ERR_UNAUTHORIZED);
       });
 
-      it("succeeds when called by trusted caller and burns tokens", () => {
+      it("fails when owner is trying to burn more tokens than he owns", () => {
+        const owner = accounts.get("wallet_5")!;
+        const amount = 8888912313;
+
+        // act
+        const receipt = chain.mineBlock([
+          token.burn(amount, owner, owner),
+        ]).receipts[0];
+
+        receipt.result.expectErr().expectUint(1); // 1 is standard ft-burn error code
+      })
+
+      it("succeeds when called by tokens owner and burns correct amount of  tokens", () => {
         // arrange
-        const wallet = accounts.get("wallet_1")!;
+        const owner = accounts.get("wallet_1")!;
         const amount = 300;
         chain.mineBlock([
-          token.ftMint(amount, wallet),
-          core.testInitializeCore(core.address),
+          token.ftMint(amount, owner)
         ]);
 
         // act
         const receipt = chain.mineBlock([
-          core.testBurn(amount, wallet, wallet),
+          token.burn(amount, owner, owner),
         ]).receipts[0];
 
         // assert
@@ -229,12 +241,13 @@ describe("[CityCoin Token]", () => {
 
         receipt.events.expectFungibleTokenBurnEvent(
           amount,
-          wallet.address,
+          owner.address,
           "citycoins"
         );
       });
     });
   });
+
   describe("UTILITIES", () => {
     describe("mint()", () => {
       it("fails with ERR_CORE_CONTRACT_NOT_FOUND when called by someone who is not a trusted caller", () => {


### PR DESCRIPTION
This PR removes restriction we imposed on `burn` function and unlocks it for all token owners.

`ft-burn` requires a post-conditions if transaction that executes it is submitted in `deny` mode, therefore guarding it with `tx-sender` is sufficient and using `contract-caller` instead would be excessive.

Because `burn` will be open for everyone we no longer need `test-burn` function in `core` contract addon so it has been removed.

close #149 