### PR TITLE
Add printing tuple with first and last stacking cycle

### DIFF
--- a/contracts/citycoin-core-v1.clar
+++ b/contracts/citycoin-core-v1.clar
@@ -670,6 +670,10 @@
       (err ERR_CANNOT_STACK))
     (asserts! (> amountTokens u0) (err ERR_CANNOT_STACK))
     (try! (contract-call? .citycoin-token transfer amountTokens tx-sender (as-contract tx-sender) none))
+    (print {
+      firstCycle: targetCycle, 
+      lastCycle: (- (+ targetCycle lockPeriod) u1)
+    })
     (match (fold stack-tokens-closure REWARD_CYCLE_INDEXES (ok commitment))
       okValue (ok true)
       errValue (err errValue)

--- a/contracts/clarinet/citycoin-core-v1.clar
+++ b/contracts/clarinet/citycoin-core-v1.clar
@@ -670,6 +670,10 @@
       (err ERR_CANNOT_STACK))
     (asserts! (> amountTokens u0) (err ERR_CANNOT_STACK))
     (try! (contract-call? .citycoin-token transfer amountTokens tx-sender (as-contract tx-sender) none))
+    (print {
+      firstCycle: targetCycle, 
+      lastCycle: (- (+ targetCycle lockPeriod) u1)
+    })
     (match (fold stack-tokens-closure REWARD_CYCLE_INDEXES (ok commitment))
       okValue (ok true)
       errValue (err errValue)


### PR DESCRIPTION
PR introduces printed tuple with first and last stacking cycle used while calling `stack-tokens`.

It will make our contract a little bit more verbose and will help users to verify what is their first reward cycle, and when they'll be able to get back their tokens.

Just like in #153 I had to adjust few existing tests, by increasing number of expected events by 1.

close #150