### PR TITLE
Fix version numbering

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -23,5 +23,4 @@ comment:
 
 ignore:
   - "contracts/clarinet/citycoin-tardis-v1.clar"
-  - "contracts/clarinet/citycoin-tardis-v1-mainnet.clar"
   - "contracts/clarinet/citycoin-core-v2.clar"

--- a/contracts/MiamiCoin/auth.clar
+++ b/contracts/MiamiCoin/auth.clar
@@ -1,5 +1,5 @@
 ;; MIAMICOIN AUTH CONTRACT
-;; CityCoins Protocol Version 1.0.2
+;; CityCoins Protocol Version 1.2.0
 
 (define-constant CONTRACT_OWNER tx-sender)
 

--- a/contracts/MiamiCoin/core-v1.clar
+++ b/contracts/MiamiCoin/core-v1.clar
@@ -1,5 +1,5 @@
 ;; MIAMICOIN CORE CONTRACT
-;; CityCoins Protocol Version 1.0.2
+;; CityCoins Protocol Version 1.2.0
 
 ;; GENERAL CONFIGURATION
 

--- a/contracts/MiamiCoin/token.clar
+++ b/contracts/MiamiCoin/token.clar
@@ -1,5 +1,5 @@
 ;; MIAMICOIN TOKEN CONTRACT
-;; CityCoins Protocol Version 1.0.2
+;; CityCoins Protocol Version 1.2.0
 
 (define-constant CONTRACT_OWNER tx-sender)
 

--- a/contracts/NewYorkCityCoin/auth.clar
+++ b/contracts/NewYorkCityCoin/auth.clar
@@ -1,5 +1,5 @@
 ;; NEWYORKCITYCOIN AUTH CONTRACT
-;; CityCoins Protocol Version 1.0.2
+;; CityCoins Protocol Version 1.2.0
 
 (define-constant CONTRACT_OWNER tx-sender)
 

--- a/contracts/NewYorkCityCoin/core-v1.clar
+++ b/contracts/NewYorkCityCoin/core-v1.clar
@@ -1,5 +1,5 @@
 ;; NEWYORKCITYCOIN CORE CONTRACT
-;; CityCoins Protocol Version 1.0.2
+;; CityCoins Protocol Version 1.2.0
 
 ;; GENERAL CONFIGURATION
 

--- a/contracts/NewYorkCityCoin/token.clar
+++ b/contracts/NewYorkCityCoin/token.clar
@@ -1,5 +1,5 @@
 ;; NEWYORKCITYCOIN TOKEN CONTRACT
-;; CityCoins Protocol Version 1.0.2
+;; CityCoins Protocol Version 1.2.0
 
 (define-constant CONTRACT_OWNER tx-sender)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "citycoin",
-  "version": "1.0.2",
+  "version": "1.2.0",
   "description": "A smart contract implementation of the Proof of Transfer consensus mechanism, allowing for the mining and Stacking of a new fungible token on the Stacks blockchain with a portion of miner rewards going to a custodied account for a city to claim the protocol contribution.",
   "scripts": {
     "test": "npm run clarinet:test",


### PR DESCRIPTION
This PR corrects a few spots where it was listed as `1.0.2` instead of `1.2.0`.

Also removes an unused contract reference from the codecov.yml file.

After this one we can create the annotated tag on the main branch prior to any protocol changes if the vote passes.