### PR TITLE
Remove unused variables

### DIFF
--- a/contracts/MiamiCoin/core-v1.clar
+++ b/contracts/MiamiCoin/core-v1.clar
@@ -707,9 +707,6 @@
         (firstCycle (get first commitment))
         (lastCycle (get last commitment))
         (targetCycle (+ firstCycle rewardCycleIdx))
-        (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle stackerId))
-        (amountStacked (get amountStacked stackerAtCycle))
-        (toReturn (get toReturn stackerAtCycle))
       )
       (begin
         (if (and (>= targetCycle firstCycle) (< targetCycle lastCycle))

--- a/contracts/NewYorkCityCoin/core-v1.clar
+++ b/contracts/NewYorkCityCoin/core-v1.clar
@@ -707,9 +707,6 @@
         (firstCycle (get first commitment))
         (lastCycle (get last commitment))
         (targetCycle (+ firstCycle rewardCycleIdx))
-        (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle stackerId))
-        (amountStacked (get amountStacked stackerAtCycle))
-        (toReturn (get toReturn stackerAtCycle))
       )
       (begin
         (if (and (>= targetCycle firstCycle) (< targetCycle lastCycle))

--- a/contracts/citycoin-core-v1.clar
+++ b/contracts/citycoin-core-v1.clar
@@ -706,9 +706,6 @@
         (firstCycle (get first commitment))
         (lastCycle (get last commitment))
         (targetCycle (+ firstCycle rewardCycleIdx))
-        (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle stackerId))
-        (amountStacked (get amountStacked stackerAtCycle))
-        (toReturn (get toReturn stackerAtCycle))
       )
       (begin
         (if (and (>= targetCycle firstCycle) (< targetCycle lastCycle))

--- a/contracts/citycoin-core-v2.clar
+++ b/contracts/citycoin-core-v2.clar
@@ -706,9 +706,6 @@
         (firstCycle (get first commitment))
         (lastCycle (get last commitment))
         (targetCycle (+ firstCycle rewardCycleIdx))
-        (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle stackerId))
-        (amountStacked (get amountStacked stackerAtCycle))
-        (toReturn (get toReturn stackerAtCycle))
       )
       (begin
         (if (and (>= targetCycle firstCycle) (< targetCycle lastCycle))

--- a/contracts/clarinet/citycoin-core-v1.clar
+++ b/contracts/clarinet/citycoin-core-v1.clar
@@ -706,9 +706,6 @@
         (firstCycle (get first commitment))
         (lastCycle (get last commitment))
         (targetCycle (+ firstCycle rewardCycleIdx))
-        (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle stackerId))
-        (amountStacked (get amountStacked stackerAtCycle))
-        (toReturn (get toReturn stackerAtCycle))
       )
       (begin
         (if (and (>= targetCycle firstCycle) (< targetCycle lastCycle))

--- a/contracts/clarinet/citycoin-core-v2.clar
+++ b/contracts/clarinet/citycoin-core-v2.clar
@@ -706,9 +706,6 @@
         (firstCycle (get first commitment))
         (lastCycle (get last commitment))
         (targetCycle (+ firstCycle rewardCycleIdx))
-        (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle stackerId))
-        (amountStacked (get amountStacked stackerAtCycle))
-        (toReturn (get toReturn stackerAtCycle))
       )
       (begin
         (if (and (>= targetCycle firstCycle) (< targetCycle lastCycle))


### PR DESCRIPTION
There were a few unused variables in `stack-tokens-closure`, this PR removes them from all core contract instances.